### PR TITLE
Fix UART device type parsing and extend tests

### DIFF
--- a/queclink_tramas.py
+++ b/queclink_tramas.py
@@ -242,7 +242,7 @@ def parse_model_specific(device: str, fields: List[str], start_idx: int) -> Dict
             out["backup_batt_pct"] = val; cursor += 1
     if cursor < len(remaining) and re.fullmatch(r"[0-9A-Fa-f]{6,10}", remaining[cursor] or ""):
         out["device_status"] = (remaining[cursor] or "").upper(); cursor += 1
-    if cursor < len(remaining) and re.fullmatch(r"\\d{1,2}", remaining[cursor] or ""):
+    if cursor < len(remaining) and re.fullmatch(r"\d{1,2}", remaining[cursor] or ""):
         out["uart_device_type"] = safe_int(remaining[cursor]); cursor += 1
     out["remaining_blob"] = ",".join(remaining[cursor:])
     return out

--- a/tests/gv310lau/test_gteri_parser.py
+++ b/tests/gv310lau/test_gteri_parser.py
@@ -80,6 +80,14 @@ RAW_HDOP0 = (
 )
 
 
+RAW_UART_DUP_ZERO = (
+    "+RESP:GTERI,6E1203,864696060004173,GV310LAU,00000100,,10,1,1,0.0,0,115.8,"
+    "117.129356,31.839248,20230808061540,0460,0001,DF5C,05FE6667,03,15,,4.0,"
+    "0000102:34:33,14549,42,11172,100,220100,0,0,06,12,0,001A42A2,0617,TMPS,"
+    "08351B00043C,1,26,65,20231030085704,20231030085704,0017$"
+)
+
+
 def test_parse_gteri_campos_basicos():
     d = parse_gteri(RAW_OK)
     assert isinstance(d, dict)
@@ -163,4 +171,18 @@ def test_campos_post_dop_no_se_desplazan():
     assert d.get("analog_in_2") in {"11172", 11172}
     assert d.get("backup_batt_pct") == 100
     assert str(d.get("device_status", "")).upper() == "210000"
-    assert d.get("remaining_blob") == "0,1,0,06,12,0,001A42A2,0617,TMPS,08351B00043C,1,26,65,20231030085704"
+    assert d.get("remaining_blob") == "1,0,06,12,0,001A42A2,0617,TMPS,08351B00043C,1,26,65,20231030085704"
+
+
+def test_uart_device_type_extraido_y_fuera_del_blob():
+    d = parse_gteri(RAW_UART_DUP_ZERO)
+
+    assert isinstance(d.get("uart_device_type"), int)
+    assert d.get("uart_device_type") == 0
+
+    assert d.get("device_status") in {"220100", 220100}
+
+    remaining = d.get("remaining_blob") or ""
+    # Antes la secuencia quedaba como ",,,100,220100,0,0,..."; al extraer el UART
+    # desaparece el primer "0" y ya no existe "0,0,06" en el remanente.
+    assert "0,0,06" not in remaining


### PR DESCRIPTION
## Summary
- adjust the UART device type regex to match actual digit values and avoid leaving it inside the remaining blob
- extend GV310LAU parser tests to cover frames ending in ",,,100,220100,0,0" and update expectations for the reference sample

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e00f0c09fc83338dbfa5b67655e0c4