### PR TITLE
Resolve UART device type merge conflict

### DIFF
--- a/queclink_tramas.py
+++ b/queclink_tramas.py
@@ -256,7 +256,11 @@ def parse_model_specific(device: str, fields: List[str], start_idx: int) -> Dict
         out["device_status"] = (remaining[cursor] or "").upper(); cursor += 1
     skip_empty_values()
     if cursor < len(remaining) and re.fullmatch(r"\d{1,2}", remaining[cursor] or ""):
-        out["uart_device_type"] = safe_int(remaining[cursor]); cursor += 1
+        parsed_uart = safe_int(remaining[cursor])
+        if parsed_uart is not None:
+            out["uart_device_type"] = parsed_uart
+        cursor += 1
+    skip_empty_values()
     out["remaining_blob"] = ",".join(remaining[cursor:])
     return out
 

--- a/tests/gv310lau/test_gteri_parser.py
+++ b/tests/gv310lau/test_gteri_parser.py
@@ -86,6 +86,13 @@ RAW_ANALOG_PLACEHOLDERS = (
     "08351B00043C,1,26,65,20231030085704,20231030085704,0017$"
 )
 
+RAW_UART_DUP_ZERO = (
+    "+RESP:GTERI,6E1203,864696060004173,GV310LAU,00000100,,10,1,1,0.0,0,115.8,"
+    "117.129356,31.839248,20230808061540,0460,0001,DF5C,05FE6667,03,15,,4.0,"
+    "0000102:34:33,14549,,,,100,220100,0,0,06,12,0,001A42A2,0617,TMPS,"
+    "08351B00043C,1,26,65,20231030085704,20231030085704,0017$"
+)
+
 
 def test_parse_gteri_campos_basicos():
     d = parse_gteri(RAW_OK)
@@ -182,3 +189,11 @@ def test_placeholders_no_bloquean_campos_posteriores():
     assert d.get("backup_batt_pct") == 100
     assert d.get("device_status") == "220100"
     assert d.get("uart_device_type") == 0
+
+
+def test_uart_device_type_dup_zero():
+    d = parse_gteri(RAW_UART_DUP_ZERO)
+
+    assert isinstance(d.get("uart_device_type"), int)
+    remaining_blob = d.get("remaining_blob", "") or ""
+    assert "0,0,06" not in remaining_blob


### PR DESCRIPTION
## Summary
- ensure uart_device_type parsing stores an integer before building the remaining blob
- skip empty tokens after consuming the uart field so remaining_blob does not duplicate zeros
- add regression coverage for duplicate zero UART payloads in GV310LAU tests

## Testing
- pytest tests/gv310lau/test_gteri_parser.py

------
https://chatgpt.com/codex/tasks/task_e_68e0125eaf6c8333b480f38a7de16e65