### PR TITLE
Extract digital fuel sensor data when ERI mask flag set

### DIFF
--- a/queclink_tramas.py
+++ b/queclink_tramas.py
@@ -151,6 +151,7 @@ def parse_model_specific(device: str, fields: List[str], start_idx: int) -> Dict
                 return None
 
     mask_value = to_mask_value(fields[start_idx - 1] if start_idx - 1 < len(fields) else None)
+    eri_mask_value = to_mask_value(fields[4] if len(fields) > 4 else None)
 
     def mask_has(bit: int) -> bool:
         return mask_value is not None and (mask_value & bit) != 0
@@ -259,6 +260,15 @@ def parse_model_specific(device: str, fields: List[str], start_idx: int) -> Dict
         parsed_uart = safe_int(remaining[cursor])
         if parsed_uart is not None:
             out["uart_device_type"] = parsed_uart
+        cursor += 1
+    skip_empty_values()
+    if (
+        eri_mask_value is not None
+        and (eri_mask_value & 0x01) != 0
+        and "uart_device_type" in out
+        and cursor < len(remaining)
+    ):
+        out["digital_fuel_sensor_data"] = remaining[cursor]
         cursor += 1
     skip_empty_values()
     out["remaining_blob"] = ",".join(remaining[cursor:])

--- a/tests/gv310lau/test_gteri_parser.py
+++ b/tests/gv310lau/test_gteri_parser.py
@@ -93,6 +93,13 @@ RAW_UART_DUP_ZERO = (
     "08351B00043C,1,26,65,20231030085704,20231030085704,0017$"
 )
 
+RAW_WITH_DIGITAL_FUEL = (
+    "+RESP:GTERI,6E1203,864696060004173,GV310LAU,00000101,,10,1,1,0.0,0,115.8,"
+    "117.129356,31.839248,20230808061540,0460,0001,DF5C,05FE6667,03,15,,4.0,"
+    "0000102:34:33,14549,42,11172,100,210000,0,FUEL123,1,0,06,12,0,001A42A2,"
+    "0617,TMPS,08351B00043C,1,26,65,20231030085704,20231030085704,0017$"
+)
+
 
 def test_parse_gteri_campos_basicos():
     d = parse_gteri(RAW_OK)
@@ -197,3 +204,13 @@ def test_uart_device_type_dup_zero():
     assert isinstance(d.get("uart_device_type"), int)
     remaining_blob = d.get("remaining_blob", "") or ""
     assert "0,0,06" not in remaining_blob
+
+
+def test_digital_fuel_sensor_data_consumed():
+    d = parse_gteri(RAW_WITH_DIGITAL_FUEL)
+
+    assert d.get("uart_device_type") == 0
+    assert d.get("digital_fuel_sensor_data") == "FUEL123"
+    remaining_blob = d.get("remaining_blob", "") or ""
+    assert "FUEL123" not in remaining_blob
+    assert remaining_blob.startswith("1,0,06")


### PR DESCRIPTION
## Summary
- read the ERI mask to detect when digital fuel sensor data is present
- store the digital fuel sensor value right after uart_device_type and keep the remaining blob intact
- add a GV310LAU parser test covering ERI mask bit 0 with digital fuel payload

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e02a91a2808333a876ee7139e4a2ba