### PR TITLE
Remove GV310LAU non-protocol columns from database export

### DIFF
--- a/docs/gv310lau/gteri.md
+++ b/docs/gv310lau/gteri.md
@@ -210,7 +210,6 @@ Estructura JSON sugerida para `parse_gteri(trama: str) -> dict`:
   "hour_meter": "0000102:34:33",
   "ai1": 42,
   "ai2": 11172,
-  "backup_batt_pct": 100,
   "device_status": "210000",
   "uart_type": 0,
   "fuel": { "type": "TMPS", "raw": "08351B00043C" },

--- a/tests/gv310lau/test_gteri_parser.py
+++ b/tests/gv310lau/test_gteri_parser.py
@@ -180,7 +180,7 @@ def test_rangos_basicos():
     d = parse_gteri(RAW_OK)
     assert -90 <= d.get("lat") <= 90
     assert -180 <= d.get("lon") <= 180
-    assert 0 <= d.get("backup_batt_pct", 0) <= 100
+    assert "backup_batt_pct" not in d
 
 
 def test_valida_hour_meter_formato():
@@ -195,26 +195,26 @@ def test_campos_post_dop_no_se_desplazan():
     assert d.get("mileage_km") == pytest.approx(14549.0)
     assert d.get("hour_meter") == "0000102:34:33"
     assert d.get("analog_in_1") == 42
-    assert d.get("analog_in_1_mv") == 42
-    assert d.get("analog_in_1_pct") == pytest.approx(0.26, rel=1e-2, abs=1e-2)
-    assert d.get("analog_in_1_raw") == "42"
     assert d.get("analog_in_2") == 11172
-    assert d.get("analog_in_2_mv") == 11172
-    assert d.get("analog_in_2_pct") == pytest.approx(69.83, rel=1e-3, abs=1e-2)
-    assert d.get("analog_in_2_raw") == "11172"
     assert d.get("analog_in_3") is None
-    assert d.get("analog_in_3_mv") is None
-    assert d.get("analog_in_3_pct") is None
-    assert d.get("analog_in_3_raw") in (None, "")
-    assert d.get("backup_batt_pct") == 100
-    assert d.get("backup_batt_pct_raw") == pytest.approx(100.0)
     assert str(d.get("device_status", "")).upper() == "210000"
-    assert d.get("device_status_len_bits") == 24
-    assert d.get("device_status_raw") == "210000"
-    assert d.get("remaining_blob") == "1,0,06,12,0,001A42A2,0617,TMPS,08351B00043C,1,26,65,20231030085704"
-    assert d.get("uart_device_type_label") == "unknown"
-    assert d.get("validation_warning") in (0, False)
-    assert d.get("validation_warnings_json") in (None, "[]")
+    assert "analog_in_1_raw" not in d
+    assert "analog_in_1_mv" not in d
+    assert "analog_in_1_pct" not in d
+    assert "analog_in_2_raw" not in d
+    assert "analog_in_2_mv" not in d
+    assert "analog_in_2_pct" not in d
+    assert "analog_in_3_raw" not in d
+    assert "analog_in_3_mv" not in d
+    assert "analog_in_3_pct" not in d
+    assert "backup_batt_pct" not in d
+    assert "backup_batt_pct_raw" not in d
+    assert "device_status_len_bits" not in d
+    assert "device_status_raw" not in d
+    assert "remaining_blob" not in d
+    assert "uart_device_type_label" not in d
+    assert "validation_warning" not in d
+    assert "validation_warnings_json" not in d
 
 
 def test_placeholders_no_bloquean_campos_posteriores():
@@ -223,22 +223,20 @@ def test_placeholders_no_bloquean_campos_posteriores():
     assert d.get("analog_in_1") is None
     assert d.get("analog_in_2") is None
     assert d.get("analog_in_3") is None
-    assert d.get("analog_in_1_raw") in (None, "")
-    assert d.get("analog_in_2_raw") in (None, "")
-    assert d.get("analog_in_3_raw") in (None, "")
-    assert d.get("backup_batt_pct") == 100
+    assert "analog_in_1_raw" not in d
+    assert "analog_in_2_raw" not in d
+    assert "analog_in_3_raw" not in d
+    assert "backup_batt_pct" not in d
     assert d.get("device_status") == "220100"
     assert d.get("uart_device_type") == 0
-    assert d.get("uart_device_type_label") == "unknown"
+    assert "uart_device_type_label" not in d
 
 
 def test_uart_device_type_dup_zero():
     d = parse_gteri(RAW_UART_DUP_ZERO)
 
     assert isinstance(d.get("uart_device_type"), int)
-    assert d.get("uart_device_type_label") == "unknown"
-    remaining_blob = d.get("remaining_blob", "") or ""
-    assert "0,0,06" not in remaining_blob
+    assert "uart_device_type_label" not in d
 
 
 def test_digital_fuel_sensor_data_consumed():
@@ -246,25 +244,22 @@ def test_digital_fuel_sensor_data_consumed():
 
     assert d.get("uart_device_type") == 0
     assert d.get("digital_fuel_sensor_data") == "FUEL123|LEVEL80"
-    assert d.get("dfs_raw_list") == '["FUEL123", "LEVEL80"]'
-    assert d.get("dfs_count") == 2
-    remaining_blob = d.get("remaining_blob", "") or ""
-    assert "FUEL123" not in remaining_blob
-    assert remaining_blob.startswith("1,0,06")
+    assert "dfs_raw_list" not in d
+    assert "dfs_count" not in d
 
 
 def test_analog_f_normalization():
     d = parse_gteri(RAW_ANALOG_NORMALIZED)
 
     assert d.get("analog_in_1") == 8000
-    assert d.get("analog_in_1_mv") == 8000
-    assert d.get("analog_in_1_pct") == 50.0
     assert d.get("analog_in_2") == 8000
-    assert d.get("analog_in_2_pct") == 50.0
     assert d.get("analog_in_3") == 22500
-    assert d.get("analog_in_3_pct") == 75.0
-    assert d.get("validation_warning") in (0, False)
-    assert d.get("validation_warnings_json") in (None, "[]")
+    assert "analog_in_1_mv" not in d
+    assert "analog_in_1_pct" not in d
+    assert "analog_in_2_pct" not in d
+    assert "analog_in_3_pct" not in d
+    assert "validation_warning" not in d
+    assert "validation_warnings_json" not in d
 
 
 def test_warn_when_values_outside_range():
@@ -273,23 +268,21 @@ def test_warn_when_values_outside_range():
     assert d.get("analog_in_1") == 16000
     assert d.get("analog_in_2") == 0
     assert d.get("analog_in_3") == 30000
-    assert d.get("backup_batt_pct") == 100
-    assert d.get("backup_batt_pct_raw") == pytest.approx(130.0)
     assert d.get("device_status") == "0000000000-0F0FFFFFFF"
-    assert d.get("device_status_len_bits") == 80
-    assert d.get("device_status_hi") == "0000000000"
-    assert d.get("device_status_lo") == "0F0FFFFFFF"
     assert d.get("uart_device_type") == 3
-    assert d.get("uart_device_type_label") == "invalid"
     assert d.get("digital_fuel_sensor_data") == "FUELX|DATA"
-    assert d.get("dfs_count") == 2
-    assert d.get("dfs_raw_list") == '["FUELX", "DATA"]'
+    assert "backup_batt_pct" not in d
+    assert "backup_batt_pct_raw" not in d
+    assert "device_status_len_bits" not in d
+    assert "device_status_hi" not in d
+    assert "device_status_lo" not in d
+    assert "uart_device_type_label" not in d
+    assert "dfs_count" not in d
+    assert "dfs_raw_list" not in d
     warnings = set(d.get("validation_warnings") or [])
     assert "analog_in_1_mv_clamped" in warnings
     assert "analog_in_2_mv_clamped" in warnings
     assert "analog_in_3_mv_clamped" in warnings
     assert "backup_batt_pct_clamped" in warnings
     assert "uart_device_type_invalid" in warnings
-    assert d.get("validation_warning") in (1, True)
-    warnings_json = d.get("validation_warnings_json") or ""
-    assert "analog_in_1_mv_clamped" in warnings_json
+    assert "validation_warning" not in d


### PR DESCRIPTION
## Summary
- drop the GV310LAU non-protocol columns from the SQLite schema and record serialization
- strip the removed fields from parsed records while preserving validation warnings
- align the GV310LAU documentation and parser tests with the slimmer export payload

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3bbe8f7e88333a1087986b575f3c8