### PR TITLE
feat(viz): mapas diarios folium con buffer/no-buffer y dirección

### DIFF
--- a/.github/workflows/viz.yml
+++ b/.github/workflows/viz.yml
@@ -1,0 +1,80 @@
+name: viz
+
+on:
+  push:
+    branches:
+      - main
+      - "feat/**"
+  pull_request:
+    paths:
+      - "viz/**"
+      - "tests/viz/**"
+      - "docs/viz/**"
+      - "README.md"
+      - ".github/workflows/viz.yml"
+      - "spec/viz_maps.yml"
+
+jobs:
+  build-map:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install folium pytz python-dateutil pytest
+      - name: Run viz tests
+        run: pytest tests/viz
+      - name: Generar mapa de ejemplo
+        run: |
+          python - <<'PY'
+          import pathlib
+          import sqlite3
+
+          from viz.query import fetch_points_by_day
+          from viz.folium_map import render_map
+
+          artifacts = pathlib.Path("artifacts")
+          artifacts.mkdir(exist_ok=True)
+
+          db_path = artifacts / "sample.db"
+          conn = sqlite3.connect(db_path)
+          try:
+              conn.executescript(
+                  """
+                  CREATE TABLE IF NOT EXISTS gteri_records (
+                      lon REAL,
+                      lat REAL,
+                      gnss_utc TEXT,
+                      is_buff INTEGER,
+                      report_type TEXT,
+                      imei TEXT
+                  );
+                  DELETE FROM gteri_records;
+                  """
+              )
+              sample_rows = [
+                  (-70.6500, -33.4372, "20230801060000", 0, "10", "123456789012345"),
+                  (-70.6515, -33.4380, "20230801063000", 0, "10", "123456789012345"),
+                  (-70.6530, -33.4395, "20230801070000", 1, "10", "123456789012345"),
+                  (-70.6545, -33.4405, "20230801073000", 1, "10", "123456789012345"),
+              ]
+              conn.executemany(
+                  "INSERT INTO gteri_records(lon, lat, gnss_utc, is_buff, report_type, imei) VALUES(?,?,?,?,?,?)",
+                  sample_rows,
+              )
+              conn.commit()
+          finally:
+              conn.close()
+
+          points = fetch_points_by_day(str(db_path), "123456789012345", "2023-08-01")
+          render_map(points, str(artifacts / "map.html"), str(artifacts / "map.geojson"))
+          PY
+      - name: Publicar artefactos
+        uses: actions/upload-artifact@v3
+        with:
+          name: viz-map
+          path: artifacts

--- a/.github/workflows/viz.yml
+++ b/.github/workflows/viz.yml
@@ -74,7 +74,7 @@ jobs:
           render_map(points, str(artifacts / "map.html"), str(artifacts / "map.geojson"))
           PY
       - name: Publicar artefactos
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: viz-map
           path: artifacts

--- a/README.md
+++ b/README.md
@@ -1,2 +1,58 @@
 # Queclinck-Homlogador-Tramas
-Homologa tramas de Queclink
+
+Herramientas para homologar y analizar tramas Queclink (`+RESP:GTERI`) de los modelos
+GV310LAU, GV58LAU y GV350CEU. Permite convertir archivos de texto/CSV/XLSX a una base de datos
+SQLite y, a partir de ella, generar mapas diarios con los recorridos diferenciando entre
+reportes buffer y no buffer.
+
+## Requisitos
+
+- Python 3.9 o superior.
+- Dependencias opcionales del parser: `pandas` y `openpyxl` (para leer CSV/XLSX).
+- Dependencias del módulo de visualización: `folium`, `pytz`, `python-dateutil`.
+
+Instala los paquetes mínimos para los mapas con:
+
+```bash
+pip install folium pytz python-dateutil
+```
+
+## Parser de tramas GTERI
+
+Ejemplo rápido para convertir un archivo de tramas a SQLite:
+
+```bash
+python queclink_tramas.py --in datos.txt --out salida.db
+```
+
+Consulta la carpeta `docs/` para detalles del protocolo y campos disponibles.
+
+## Visualización de recorridos diarios
+
+El módulo `viz` entrega un CLI que genera un mapa HTML (Folium) y un GeoJSON agrupando los
+recorridos por día local (`America/Santiago`). Los puntos buffer se dibujan en rojo y los
+reportes directos en azul, incluyendo tooltips con hora local y coordenadas.
+
+```bash
+python -m viz.cli \
+  --db salida.db \
+  --imei 864696060004173 \
+  --date 2023-08-01 \
+  --provider "CartoDB Positron" \
+  --out mapas/gv310lau_2023-08-01
+```
+
+El comando anterior creará los archivos:
+
+- `mapas/gv310lau_2023-08-01.html`: mapa interactivo listo para compartir.
+- `mapas/gv310lau_2023-08-01.geojson`: puntos del recorrido con hora local y tipo de reporte.
+
+Para más ejemplos y capturas de pantalla revisa `docs/viz/mapas.md`.
+
+## Pruebas
+
+Ejecuta los tests (incluye las validaciones del módulo de visualización):
+
+```bash
+pytest
+```

--- a/docs/viz/img/ejemplo.svg
+++ b/docs/viz/img/ejemplo.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="480" viewBox="0 0 800 480">
+  <rect width="800" height="480" fill="#f5f5f5" />
+  <text x="30" y="50" font-size="28" font-family="Arial" fill="#333">Mapa diario Folium (ejemplo referencial)</text>
+  <rect x="30" y="70" width="300" height="60" rx="8" fill="#ffffff" stroke="#cccccc" />
+  <circle cx="60" cy="100" r="10" fill="#007bff" />
+  <text x="80" y="107" font-size="18" font-family="Arial" fill="#333">Reporte directo (azul)</text>
+  <rect x="360" y="70" width="300" height="60" rx="8" fill="#ffffff" stroke="#cccccc" />
+  <circle cx="390" cy="100" r="10" fill="#d9534f" />
+  <text x="410" y="107" font-size="18" font-family="Arial" fill="#333">Reporte buffer (rojo)</text>
+  <g transform="translate(80,160)">
+    <rect x="0" y="0" width="640" height="280" fill="#e0e7ef" stroke="#b0bec5" />
+    <text x="320" y="30" font-size="18" font-family="Arial" fill="#333" text-anchor="middle">Recorrido local 2023-08-01 (America/Santiago)</text>
+    <circle cx="120" cy="220" r="12" fill="#5cb85c" />
+    <text x="120" y="250" font-size="14" font-family="Arial" fill="#333" text-anchor="middle">Inicio</text>
+    <circle cx="520" cy="90" r="12" fill="#d9534f" />
+    <text x="520" y="120" font-size="14" font-family="Arial" fill="#333" text-anchor="middle">Fin</text>
+    <polyline points="120,220 260,180 360,160" stroke="#007bff" stroke-width="6" fill="none" stroke-linecap="round" />
+    <polyline points="360,160 450,130 520,90" stroke="#d9534f" stroke-width="6" fill="none" stroke-linecap="round" />
+    <text x="220" y="190" font-size="12" font-family="Arial" fill="#1d3557">08:05 CLT</text>
+    <text x="420" y="140" font-size="12" font-family="Arial" fill="#7b1e1e">08:25 CLT</text>
+    <path d="M300 170 l15 -5 l-10 -10 z" fill="#007bff" opacity="0.8" />
+    <path d="M440 120 l15 -5 l-10 -10 z" fill="#d9534f" opacity="0.8" />
+  </g>
+</svg>

--- a/docs/viz/mapas.md
+++ b/docs/viz/mapas.md
@@ -1,0 +1,52 @@
+# Mapas diarios Folium para recorridos Queclink
+
+Esta guía explica cómo generar mapas diarios con los recorridos procesados desde las tramas
+`+RESP:GTERI`. El pipeline usa Folium, trabaja con horas locales de Chile y diferencia los
+reportes **directos** (no buffer) en azul y **buffer** en rojo.
+
+![Mapa diario de ejemplo](./img/ejemplo.svg)
+
+## Preparación
+
+1. Genera una base SQLite con `queclink_tramas.py` a partir de tus archivos.
+2. Instala las dependencias del módulo de visualización:
+
+   ```bash
+   pip install folium pytz python-dateutil
+   ```
+
+3. Identifica el IMEI a visualizar (columna `imei` de la tabla `gteri_records`).
+
+## Generar un mapa diario
+
+Usa el CLI `viz` (incluido en este repositorio) indicando la fecha **local** que deseas
+analizar. El comando produce un HTML interactivo y un GeoJSON con los puntos.
+
+```bash
+python -m viz.cli \
+  --db salida.db \
+  --imei 864696060004173 \
+  --date 2023-08-01 \
+  --provider "CartoDB Positron" \
+  --out salidas/mapa_diario
+```
+
+Salida esperada:
+
+```
+Mapa generado: salidas/mapa_diario.html
+GeoJSON generado: salidas/mapa_diario.geojson
+```
+
+### Convenciones del mapa
+
+- **Azul**: reportes directos (`+RESP:GTERI`).
+- **Rojo**: reportes buffer (`+BUFF:GTERI`).
+- Los tooltips muestran hora local (`America/Santiago`), coordenadas y tipo de reporte.
+- El mapa incluye marcadores de inicio/fin, flechas con dirección y capas activables.
+
+## Automatización en CI
+
+El workflow `viz.yml` (GitHub Actions) ejecuta pruebas del módulo, genera un mapa de ejemplo y
+publica los artefactos HTML/GeoJSON para revisión rápida. Puedes reutilizarlo como plantilla para
+otros proyectos o entornos.

--- a/spec/viz_maps.yml
+++ b/spec/viz_maps.yml
@@ -1,0 +1,20 @@
+name: viz_maps
+summary: >-
+  Visualización de recorridos diarios en mapas interactivos Folium
+  diferenciando reportes buffer y no buffer, con conversión a hora local de Chile.
+acceptance_criteria:
+  - Se genera un módulo `viz` con funciones para consultar puntos diarios desde la base SQLite y
+    renderizar mapas con Folium en colores distintos para buffer/no-buffer.
+  - La función CLI permite seleccionar base de datos, IMEI, fecha local chilena, proveedor de tiles
+    y ruta de salida, generando archivos HTML y GeoJSON.
+  - Los tooltips del mapa muestran la hora local convertida a `America/Santiago`, coordenadas y
+    el tipo de reporte.
+  - El repositorio incluye documentación en `docs/viz/mapas.md` y una sección actualizada en
+    el README con instrucciones de uso.
+  - Existe un workflow de GitHub Actions que ejecuta pruebas básicas del módulo y publica como
+    artefacto un mapa de ejemplo generado durante la CI.
+dependencies:
+  python:
+    - folium
+    - pytz
+    - python-dateutil

--- a/tests/viz/conftest.py
+++ b/tests/viz/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))

--- a/tests/viz/test_folium_map.py
+++ b/tests/viz/test_folium_map.py
@@ -1,0 +1,54 @@
+import json
+from datetime import datetime
+
+import pytest
+
+try:  # pragma: no cover - compatibilidad con stdlib
+    import pytz
+except ModuleNotFoundError:  # pragma: no cover - fallback sin pytz
+    from zoneinfo import ZoneInfo
+
+    class _Zone:
+        @staticmethod
+        def timezone(name: str):
+            return ZoneInfo(name)
+
+    pytz = _Zone()  # type: ignore
+
+pytest.importorskip("folium")
+
+from viz.folium_map import render_map
+
+
+def sample_points():
+    tz = pytz.timezone("America/Santiago")
+    return [
+        {
+            "lat": -33.45,
+            "lon": -70.66,
+            "dt_local": tz.localize(datetime(2023, 8, 1, 8, 0, 0)),
+            "report_type": "10",
+            "is_buffer": False,
+        },
+        {
+            "lat": -33.451,
+            "lon": -70.661,
+            "dt_local": tz.localize(datetime(2023, 8, 1, 8, 15, 0)),
+            "report_type": "10",
+            "is_buffer": True,
+        },
+    ]
+
+
+def test_render_map_creates_files(tmp_path):
+    html_path = tmp_path / "map.html"
+    geojson_path = tmp_path / "map.geojson"
+    render_map(sample_points(), str(html_path), str(geojson_path))
+    assert html_path.exists()
+    assert geojson_path.exists()
+    data = json.loads(geojson_path.read_text(encoding="utf-8"))
+    assert data["type"] == "FeatureCollection"
+    assert len(data["features"]) == 2
+    html_content = html_path.read_text(encoding="utf-8")
+    assert "Directo" in html_content
+    assert "Buffer" in html_content

--- a/tests/viz/test_folium_map.py
+++ b/tests/viz/test_folium_map.py
@@ -17,6 +17,7 @@ except ModuleNotFoundError:  # pragma: no cover - fallback sin pytz
 
 pytest.importorskip("folium")
 
+import viz.folium_map
 from viz.folium_map import render_map
 
 
@@ -33,7 +34,14 @@ def sample_points():
         {
             "lat": -33.451,
             "lon": -70.661,
-            "dt_local": tz.localize(datetime(2023, 8, 1, 8, 15, 0)),
+            "dt_local": tz.localize(datetime(2023, 8, 1, 8, 10, 0)),
+            "report_type": "10",
+            "is_buffer": False,
+        },
+        {
+            "lat": -33.452,
+            "lon": -70.662,
+            "dt_local": tz.localize(datetime(2023, 8, 1, 8, 20, 0)),
             "report_type": "10",
             "is_buffer": True,
         },
@@ -48,7 +56,24 @@ def test_render_map_creates_files(tmp_path):
     assert geojson_path.exists()
     data = json.loads(geojson_path.read_text(encoding="utf-8"))
     assert data["type"] == "FeatureCollection"
-    assert len(data["features"]) == 2
+    assert len(data["features"]) == 3
     html_content = html_path.read_text(encoding="utf-8")
     assert "Directo" in html_content
     assert "Buffer" in html_content
+
+
+def test_render_map_allows_single_point_segments(monkeypatch, tmp_path):
+    html_path = tmp_path / "single.html"
+    geojson_path = tmp_path / "single.geojson"
+
+    original_polyline = viz.folium_map.PolyLine
+
+    def _guarded_polyline(coords, *args, **kwargs):
+        assert len(coords) >= 2, "PolyLine should receive at least two coordinates"
+        return original_polyline(coords, *args, **kwargs)
+
+    monkeypatch.setattr(viz.folium_map, "PolyLine", _guarded_polyline)
+
+    render_map(sample_points()[:2], str(html_path), str(geojson_path))
+    assert html_path.exists()
+    assert geojson_path.exists()

--- a/tests/viz/test_geo.py
+++ b/tests/viz/test_geo.py
@@ -1,0 +1,14 @@
+from viz.geo import bearing, bearing_to_cardinal
+
+
+def test_bearing_cardinal():
+    santiago = {"lat": -33.45, "lon": -70.66}
+    valparaiso = {"lat": -33.047, "lon": -71.6127}
+    angle = bearing(santiago, valparaiso)
+    assert 290 <= angle <= 305  # Oeste-noroeste aproximado
+    assert bearing_to_cardinal(angle) in {"ONO", "NO"}
+
+
+def test_bearing_precision():
+    assert bearing_to_cardinal(0, precision=4) == "N"
+    assert bearing_to_cardinal(90, precision=4) == "E"

--- a/tests/viz/test_query.py
+++ b/tests/viz/test_query.py
@@ -1,0 +1,56 @@
+import sqlite3
+from pathlib import Path
+
+from viz.query import fetch_points_by_day
+
+
+def build_temp_db(tmp_path: Path) -> Path:
+    db_path = tmp_path / "test.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE gteri_records (
+                lon REAL,
+                lat REAL,
+                gnss_utc TEXT,
+                is_buff INTEGER,
+                report_type TEXT,
+                imei TEXT
+            );
+            """
+        )
+        rows = [
+            ( -70.6500, -33.4372, "20230801060000", 0, "10", "123"),  # 02:00 local (UTC-4)
+            ( -70.6510, -33.4380, "20230801130000", 1, "10", "123"),
+            ( -70.6520, -33.4390, "20230731230000", 0, "10", "123"),  # 19:00 local previous day
+            ( -70.6530, -33.4400, "20230802030000", 0, "10", "999"),
+        ]
+        conn.executemany(
+            "INSERT INTO gteri_records(lon, lat, gnss_utc, is_buff, report_type, imei) VALUES(?,?,?,?,?,?)",
+            rows,
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return db_path
+
+
+def test_fetch_points_by_day_filters_local_date(tmp_path):
+    db_path = build_temp_db(tmp_path)
+    points = fetch_points_by_day(str(db_path), "123", "2023-08-01")
+    assert len(points) == 2
+    for p in points:
+        tzinfo = p["dt_local"].tzinfo
+        zone_name = getattr(tzinfo, "zone", None) or getattr(tzinfo, "key", None)
+        assert zone_name == "America/Santiago"
+        assert p["dt_local"].date().isoformat() == "2023-08-01"
+    assert points[0]["is_buffer"] is False
+    assert points[1]["is_buffer"] is True
+
+
+def test_fetch_points_by_day_orden(tmp_path):
+    db_path = build_temp_db(tmp_path)
+    points = fetch_points_by_day(str(db_path), "123", "2023-08-01")
+    times = [p["dt_local"] for p in points]
+    assert times == sorted(times)

--- a/viz/__init__.py
+++ b/viz/__init__.py
@@ -1,0 +1,18 @@
+"""Utilidades para visualización de recorridos diarios con Folium."""
+from .query import fetch_points_by_day
+from .geo import bearing, bearing_to_cardinal
+
+__all__ = [
+    "fetch_points_by_day",
+    "bearing",
+    "bearing_to_cardinal",
+]
+
+try:  # pragma: no cover - folium opcional en importación
+    from .folium_map import render_map
+    __all__.append("render_map")
+except ModuleNotFoundError:  # pragma: no cover - folium no disponible
+    def render_map(*args, **kwargs):  # type: ignore[override]
+        raise ModuleNotFoundError(
+            "Se requiere instalar folium para usar viz.render_map",
+        )

--- a/viz/cli.py
+++ b/viz/cli.py
@@ -1,0 +1,69 @@
+"""CLI para generar mapas diarios de recorridos Queclink."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Tuple
+
+try:
+    from .folium_map import render_map
+    _IMPORT_ERROR = None
+except ModuleNotFoundError as exc:  # pragma: no cover - entorno sin folium
+    render_map = None  # type: ignore
+    _IMPORT_ERROR = exc
+
+from .query import fetch_points_by_day
+
+
+def _resolve_output(out: str) -> Tuple[Path, Path]:
+    path = Path(out)
+    if path.suffix.lower() == ".html":
+        html_path = path
+        geojson_path = path.with_suffix(".geojson")
+    else:
+        html_path = path.with_suffix(".html")
+        geojson_path = path.with_suffix(".geojson")
+    return html_path, geojson_path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Genera un mapa Folium diario diferenciando reportes buffer/no-buffer",
+    )
+    parser.add_argument("--db", required=True, help="Ruta a la base SQLite generada por el parser")
+    parser.add_argument("--imei", required=True, help="IMEI a consultar")
+    parser.add_argument(
+        "--date",
+        required=True,
+        help="Fecha local (America/Santiago) en formato YYYY-MM-DD",
+    )
+    parser.add_argument(
+        "--provider",
+        default="OpenStreetMap",
+        help="Nombre del proveedor de tiles para Folium (por defecto OpenStreetMap)",
+    )
+    parser.add_argument(
+        "--out",
+        required=True,
+        help="Ruta base de salida (se crearán archivos .html y .geojson)",
+    )
+    args = parser.parse_args()
+
+    if _IMPORT_ERROR is not None:
+        raise SystemExit(
+            "folium no está instalado. Ejecuta 'pip install folium pytz python-dateutil'",
+        )
+
+    html_path, geojson_path = _resolve_output(args.out)
+    points = fetch_points_by_day(args.db, args.imei, args.date)
+    if not points:
+        raise SystemExit("No se encontraron puntos para los parámetros indicados")
+
+    assert render_map is not None
+    render_map(points, str(html_path), str(geojson_path), tiles=args.provider)
+    print(f"Mapa generado: {html_path}")
+    print(f"GeoJSON generado: {geojson_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/viz/folium_map.py
+++ b/viz/folium_map.py
@@ -44,6 +44,9 @@ def _segment_color(is_buffer: bool) -> str:
 
 
 def _add_polyline(map_obj: Map, segment: List[dict]) -> None:
+    if len(segment) < 2:
+        return
+
     color = _segment_color(segment[0].get("is_buffer"))
     coords = [(p["lat"], p["lon"]) for p in segment]
     line = PolyLine(coords, color=color, weight=4, opacity=0.8)

--- a/viz/folium_map.py
+++ b/viz/folium_map.py
@@ -1,0 +1,166 @@
+"""Renderizado de mapas diarios con Folium."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable, List
+
+import folium
+from folium import FeatureGroup, Map, Marker, PolyLine
+from folium.features import DivIcon
+from folium.plugins import PolyLineTextPath
+
+from .geo import bearing, bearing_to_cardinal
+
+BUFFER_COLOR = "red"
+NON_BUFFER_COLOR = "blue"
+ARROW_SYMBOL = "➤"
+
+
+def _ensure_parent(path: Path) -> None:
+    if path.parent and not path.parent.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def _tooltip(point: dict) -> str:
+    dt_local = point["dt_local"]
+    dt_display = dt_local.strftime("%Y-%m-%d %H:%M:%S %Z")
+    coords = f"({point['lat']:.5f}, {point['lon']:.5f})"
+    report = point.get("report_type") or "?"
+    source = "Buffer" if point.get("is_buffer") else "Directo"
+    return f"{dt_display} | {coords} | {source} RT:{report}"
+
+
+def _point_direction(prev_point: dict, current_point: dict) -> str:
+    try:
+        angle = bearing(prev_point, current_point)
+    except Exception:
+        return ""
+    return f"{bearing_to_cardinal(angle)} ({angle:.0f}°)"
+
+
+def _segment_color(is_buffer: bool) -> str:
+    return BUFFER_COLOR if is_buffer else NON_BUFFER_COLOR
+
+
+def _add_polyline(map_obj: Map, segment: List[dict]) -> None:
+    color = _segment_color(segment[0].get("is_buffer"))
+    coords = [(p["lat"], p["lon"]) for p in segment]
+    line = PolyLine(coords, color=color, weight=4, opacity=0.8)
+    line.add_to(map_obj)
+    try:
+        PolyLineTextPath(
+            line,
+            ARROW_SYMBOL,
+            repeat=True,
+            offset=10,
+            attributes={"fill": color, "font-weight": "bold", "font-size": "16"},
+        ).add_to(map_obj)
+    except Exception:
+        pass
+
+
+def render_map(
+    points: Iterable[dict],
+    out_html: str,
+    out_geojson: str,
+    tiles: str = "OpenStreetMap",
+    zoom_start: int = 13,
+) -> None:
+    """Renderiza un mapa interactivo Folium con los puntos provistos."""
+
+    points_list = [p for p in points]
+    if not points_list:
+        raise ValueError("Se requieren puntos para generar el mapa")
+
+    points_list.sort(key=lambda p: p["dt_local"])
+
+    start_lat = points_list[0]["lat"]
+    start_lon = points_list[0]["lon"]
+    fmap = Map(location=(start_lat, start_lon), tiles=tiles, zoom_start=zoom_start)
+
+    buffer_group = FeatureGroup(name="Buffer", overlay=True)
+    direct_group = FeatureGroup(name="Directo", overlay=True)
+
+    last_point = None
+    current_segment: List[dict] = []
+    for point in points_list:
+        tooltip = _tooltip(point)
+        marker_group = buffer_group if point.get("is_buffer") else direct_group
+        folium.CircleMarker(
+            location=(point["lat"], point["lon"]),
+            radius=5,
+            color=_segment_color(point.get("is_buffer")),
+            fill=True,
+            fill_color=_segment_color(point.get("is_buffer")),
+            fill_opacity=0.7,
+            tooltip=tooltip,
+        ).add_to(marker_group)
+
+        if last_point is not None:
+            direction = _point_direction(last_point, point)
+            if direction:
+                Marker(
+                    location=((last_point["lat"] + point["lat"]) / 2, (last_point["lon"] + point["lon"]) / 2),
+                    icon=DivIcon(
+                        icon_size=(150, 36),
+                        icon_anchor=(0, 0),
+                        html=f'<div style="font-size: 10px; color: {_segment_color(point.get("is_buffer"))};">{direction}</div>',
+                    ),
+                ).add_to(fmap)
+
+        if current_segment and point.get("is_buffer") != current_segment[-1].get("is_buffer"):
+            _add_polyline(buffer_group if current_segment[-1].get("is_buffer") else direct_group, current_segment)
+            current_segment = []
+        current_segment.append(point)
+        last_point = point
+
+    if current_segment:
+        _add_polyline(buffer_group if current_segment[-1].get("is_buffer") else direct_group, current_segment)
+
+    buffer_group.add_to(fmap)
+    direct_group.add_to(fmap)
+    folium.LayerControl(collapsed=False).add_to(fmap)
+
+    folium.Marker(
+        location=(points_list[0]["lat"], points_list[0]["lon"]),
+        popup="Inicio",
+        icon=folium.Icon(color="green", icon="play"),
+    ).add_to(fmap)
+    folium.Marker(
+        location=(points_list[-1]["lat"], points_list[-1]["lon"]),
+        popup="Fin",
+        icon=folium.Icon(color="red", icon="stop"),
+    ).add_to(fmap)
+
+    fmap.fit_bounds([(p["lat"], p["lon"]) for p in points_list])
+
+    html_path = Path(out_html)
+    geojson_path = Path(out_geojson)
+    _ensure_parent(html_path)
+    _ensure_parent(geojson_path)
+    fmap.save(str(html_path))
+
+    feature_collection = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [point["lon"], point["lat"]],
+                },
+                "properties": {
+                    "dt_local": point["dt_local"].isoformat(),
+                    "report_type": point.get("report_type"),
+                    "is_buffer": bool(point.get("is_buffer")),
+                },
+            }
+            for point in points_list
+        ],
+    }
+    with geojson_path.open("w", encoding="utf-8") as fh:
+        json.dump(feature_collection, fh, ensure_ascii=False, indent=2)
+
+
+__all__ = ["render_map"]

--- a/viz/geo.py
+++ b/viz/geo.py
@@ -1,0 +1,66 @@
+"""Funciones geoespaciales para apoyar la visualización."""
+from __future__ import annotations
+
+import math
+from typing import Mapping, Sequence, Tuple
+
+
+def _get_coords(point: Mapping[str, float] | Sequence[float] | Tuple[float, float]) -> Tuple[float, float]:
+    if isinstance(point, Mapping):
+        lat = point.get("lat") or point.get("latitude")
+        lon = point.get("lon") or point.get("lng") or point.get("longitude")
+        if lat is None or lon is None:
+            raise ValueError("El punto no contiene lat/lon")
+        return float(lat), float(lon)
+    if isinstance(point, (tuple, list)) and len(point) >= 2:
+        return float(point[0]), float(point[1])
+    raise TypeError("Formato de punto no soportado")
+
+
+def bearing(p1, p2) -> float:
+    """Calcula el azimut (0°=Norte) entre dos puntos geográficos."""
+
+    lat1, lon1 = _get_coords(p1)
+    lat2, lon2 = _get_coords(p2)
+    lat1_rad = math.radians(lat1)
+    lat2_rad = math.radians(lat2)
+    diff_lon = math.radians(lon2 - lon1)
+    x = math.sin(diff_lon) * math.cos(lat2_rad)
+    y = math.cos(lat1_rad) * math.sin(lat2_rad) - math.sin(lat1_rad) * math.cos(lat2_rad) * math.cos(diff_lon)
+    angle = math.degrees(math.atan2(x, y))
+    return (angle + 360.0) % 360.0
+
+
+def bearing_to_cardinal(angle: float, precision: int = 16) -> str:
+    """Convierte un azimut en grados a un punto cardinal (por defecto 16 rumbos)."""
+
+    if precision not in {4, 8, 16}:
+        raise ValueError("precision debe ser 4, 8 o 16")
+    directions = {
+        4: ["N", "E", "S", "O"],
+        8: ["N", "NE", "E", "SE", "S", "SO", "O", "NO"],
+        16: [
+            "N",
+            "NNE",
+            "NE",
+            "ENE",
+            "E",
+            "ESE",
+            "SE",
+            "SSE",
+            "S",
+            "SSO",
+            "SO",
+            "OSO",
+            "O",
+            "ONO",
+            "NO",
+            "NNO",
+        ],
+    }[precision]
+    sector = 360.0 / len(directions)
+    index = int((angle + sector / 2) // sector) % len(directions)
+    return directions[index]
+
+
+__all__ = ["bearing", "bearing_to_cardinal"]

--- a/viz/query.py
+++ b/viz/query.py
@@ -1,0 +1,152 @@
+"""Consultas sobre la base SQLite para recorridos diarios."""
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import List, Optional
+
+try:
+    import pytz  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - entorno sin pytz
+    from zoneinfo import ZoneInfo
+
+    class _ZoneInfoProxy:
+        UTC = ZoneInfo("UTC")
+
+        @staticmethod
+        def timezone(name: str):
+            return ZoneInfo(name)
+
+    pytz = _ZoneInfoProxy()  # type: ignore
+
+try:
+    from dateutil import parser  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - entorno sin dateutil
+    parser = None
+
+UTC = pytz.UTC
+
+
+def _localize_utc(dt: datetime) -> datetime:
+    if hasattr(UTC, "localize"):
+        return UTC.localize(dt)  # type: ignore[attr-defined]
+    return dt.replace(tzinfo=UTC)
+
+
+@dataclass
+class TrackPoint:
+    lon: float
+    lat: float
+    dt_local: datetime
+    report_type: Optional[str]
+    is_buffer: bool
+    raw: dict
+
+    def as_dict(self) -> dict:
+        return {
+            "lon": self.lon,
+            "lat": self.lat,
+            "dt_local": self.dt_local,
+            "report_type": self.report_type,
+            "is_buffer": self.is_buffer,
+        }
+
+
+def _normalize_date(local_date: date | datetime | str) -> date:
+    if isinstance(local_date, date) and not isinstance(local_date, datetime):
+        return local_date
+    if isinstance(local_date, datetime):
+        return local_date.date()
+    if isinstance(local_date, str):
+        try:
+            if parser:
+                return parser.parse(local_date).date()
+            return datetime.fromisoformat(local_date).date()
+        except (ValueError, TypeError) as exc:
+            raise ValueError(f"Fecha inválida: {local_date}") from exc
+    raise TypeError("local_date debe ser date, datetime o str parseable")
+
+
+def _parse_utc(ts: str) -> Optional[datetime]:
+    if not ts:
+        return None
+    candidates = ["%Y%m%d%H%M%S", "%Y-%m-%dT%H:%M:%SZ", "%Y-%m-%d %H:%M:%S"]
+    for fmt in candidates:
+        try:
+            dt = datetime.strptime(ts, fmt)
+            return _localize_utc(dt)
+        except ValueError:
+            continue
+    if parser:
+        dt = parser.parse(ts)
+        if dt.tzinfo is None:
+            dt = _localize_utc(dt)
+        else:
+            dt = dt.astimezone(UTC)
+        return dt
+    for fmt in ("%Y-%m-%dT%H:%M:%S", "%Y/%m/%d %H:%M:%S"):
+        try:
+            dt = datetime.strptime(ts, fmt)
+            return _localize_utc(dt)
+        except ValueError:
+            continue
+    raise ValueError(f"Timestamp inválido: {ts}")
+
+
+def fetch_points_by_day(
+    db_path: str,
+    imei: str,
+    local_date: date | datetime | str,
+    tz: str = "America/Santiago",
+) -> List[dict]:
+    """Obtiene puntos para un día local específico ordenados por hora local."""
+
+    target_date = _normalize_date(local_date)
+    timezone = pytz.timezone(tz)
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        cur = conn.execute(
+            """
+            SELECT lon, lat, gnss_utc, is_buff, report_type
+            FROM gteri_records
+            WHERE imei = ? AND lon IS NOT NULL AND lat IS NOT NULL AND gnss_utc IS NOT NULL
+            ORDER BY gnss_utc ASC
+            """,
+            (imei,),
+        )
+        rows = cur.fetchall()
+    finally:
+        conn.close()
+
+    points: List[TrackPoint] = []
+    for row in rows:
+        utc_dt = _parse_utc(str(row["gnss_utc"]))
+        if not utc_dt:
+            continue
+        local_dt = utc_dt.astimezone(timezone)
+        if local_dt.date() != target_date:
+            continue
+        lon_val = row["lon"]
+        lat_val = row["lat"]
+        try:
+            lon_f = float(lon_val)
+            lat_f = float(lat_val)
+        except (TypeError, ValueError):
+            continue
+        track_point = TrackPoint(
+            lon=lon_f,
+            lat=lat_f,
+            dt_local=local_dt,
+            report_type=row["report_type"],
+            is_buffer=bool(row["is_buff"]),
+            raw=dict(row),
+        )
+        points.append(track_point)
+
+    points.sort(key=lambda p: p.dt_local)
+    return [p.as_dict() for p in points]
+
+
+__all__ = ["fetch_points_by_day", "TrackPoint"]


### PR DESCRIPTION
## Summary
- add the viz maps specification together with documentation and README instructions for the new folium-based daily maps
- implement the viz package (query, geo helpers, folium renderer and CLI) including fallbacks for environments without folium/pytz/dateutil
- add focused pytest coverage for the viz module and a GitHub Actions workflow that generates and uploads a sample map artifact

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e413b606cc8333935484ed9c5fef0e