### PR TITLE
Add SQLite ingestor for homologated Queclink reports

### DIFF
--- a/queclink/ingestor_sqlite.py
+++ b/queclink/ingestor_sqlite.py
@@ -1,0 +1,231 @@
+"""Herramientas para ingerir tramas homologadas en una base SQLite."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any, Dict, Iterable, Mapping, MutableMapping, Optional
+
+from .parser import parse_line
+
+MODELS = ("GV310LAU", "GV58LAU", "GV350CEU")
+REPORTS = ("GTERI", "GTINF")
+
+BASE_COLUMNS: Mapping[str, str] = {
+    "model": "TEXT",
+    "report": "TEXT",
+    "imei": "TEXT",
+    "device": "TEXT",
+    "source": "TEXT",
+    "protocol_version": "TEXT",
+    "send_time_raw": "TEXT",
+    "send_time_iso": "TEXT",
+    "count_hex": "TEXT",
+    "raw_line": "TEXT",
+}
+
+GTERI_COLUMNS: Mapping[str, str] = {
+    "header": "TEXT",
+    "prefix": "TEXT",
+    "device_name": "TEXT",
+    "model": "TEXT",
+    "version": "TEXT",
+    "report_type": "TEXT",
+    "number": "INTEGER",
+    "eri_mask": "TEXT",
+    "ext_power_mv": "INTEGER",
+    "gnss_acc": "REAL",
+    "speed_kmh": "REAL",
+    "azimuth_deg": "INTEGER",
+    "altitude_m": "REAL",
+    "lon": "REAL",
+    "lat": "REAL",
+    "gnss_utc": "TEXT",
+    "utc": "TEXT",
+    "mcc": "TEXT",
+    "mnc": "TEXT",
+    "lac": "TEXT",
+    "cell_id": "TEXT",
+    "pos_append_mask": "TEXT",
+    "raw_after_pam": "TEXT",
+    "send_time": "TEXT",
+    "satellites": "INTEGER",
+    "sats": "INTEGER",
+    "is_buff": "INTEGER",
+    "count_dec": "INTEGER",
+    "dop1": "REAL",
+    "dop2": "REAL",
+    "dop3": "REAL",
+    "gnss_trigger_type": "INTEGER",
+    "gnss_jamming_state": "INTEGER",
+    "hour_meter": "TEXT",
+    "mileage_km": "REAL",
+    "analog_in_1": "REAL",
+    "analog_in_2": "REAL",
+    "analog_in_3": "REAL",
+    "device_status": "TEXT",
+    "uart_device_type": "INTEGER",
+    "gnss_fix": "INTEGER",
+    "is_last_fix": "INTEGER",
+    "spec_path": "TEXT",
+    "raw": "TEXT",
+}
+
+GTINF_COLUMNS: Mapping[str, str] = {
+    "raw": "TEXT",
+    "header": "TEXT",
+    "spec_path": "TEXT",
+}
+
+REPORT_SCHEMAS: Mapping[str, Mapping[str, str]] = {
+    "GTERI": GTERI_COLUMNS,
+    "GTINF": GTINF_COLUMNS,
+}
+
+
+def _table_name(model: str, report: str) -> str:
+    return f"{model.strip().lower()}_{report.strip().lower()}"
+
+
+def _normalize_path(path: str | Path) -> str:
+    return str(path)
+
+
+def _column_type(report: str, column: str) -> str:
+    if column in BASE_COLUMNS:
+        return BASE_COLUMNS[column]
+    return REPORT_SCHEMAS.get(report, {}).get(column, "TEXT")
+
+
+def _existing_columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    cursor = conn.execute(f"PRAGMA table_info({table})")
+    return {row[1] for row in cursor.fetchall()}
+
+
+def _ensure_columns(
+    conn: sqlite3.Connection,
+    table: str,
+    report: str,
+    columns: Iterable[str],
+) -> None:
+    existing = _existing_columns(conn, table)
+    for column in columns:
+        if column == "id" or column in existing:
+            continue
+        col_type = _column_type(report, column)
+        conn.execute(f"ALTER TABLE {table} ADD COLUMN {column} {col_type}")
+    conn.commit()
+
+
+def init_db(path: str | Path) -> sqlite3.Connection:
+    """Crear la base SQLite y todas las tablas requeridas."""
+
+    conn = sqlite3.connect(_normalize_path(path))
+    for model in MODELS:
+        for report in REPORTS:
+            table = _table_name(model, report)
+            column_defs = ["id INTEGER PRIMARY KEY AUTOINCREMENT"]
+            seen: set[str] = set()
+            for column, col_type in BASE_COLUMNS.items():
+                if column in seen:
+                    continue
+                column_defs.append(f"{column} {col_type}")
+                seen.add(column)
+            for column, col_type in REPORT_SCHEMAS[report].items():
+                if column in seen:
+                    continue
+                column_defs.append(f"{column} {col_type}")
+                seen.add(column)
+            conn.execute(
+                f"CREATE TABLE IF NOT EXISTS {table} ({', '.join(column_defs)})"
+            )
+    conn.commit()
+    return conn
+
+
+def _normalize_value(value: Any) -> Any:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, (dict, list, tuple)):
+        return json.dumps(value)
+    return value
+
+
+def insert_parsed_record(
+    conn: sqlite3.Connection,
+    model: str,
+    report: str,
+    parsed_dict: MutableMapping[str, Any],
+) -> Optional[int]:
+    """Insertar un diccionario parseado en la tabla correspondiente."""
+
+    if not parsed_dict:
+        return None
+
+    normalized_model = model.strip().upper()
+    normalized_report = report.strip().upper()
+    table = _table_name(normalized_model, normalized_report)
+
+    parsed_dict.setdefault("model", normalized_model)
+    parsed_dict.setdefault("report", normalized_report)
+    if "raw_line" not in parsed_dict:
+        raw_value = parsed_dict.get("raw")
+        if isinstance(raw_value, str):
+            parsed_dict["raw_line"] = raw_value
+    parsed_dict.setdefault("device", parsed_dict.get("device") or normalized_model)
+
+    _ensure_columns(conn, table, normalized_report, parsed_dict.keys())
+
+    columns = [col for col in parsed_dict.keys() if col != "id"]
+    if "raw_line" not in columns:
+        columns.append("raw_line")
+    columns = list(dict.fromkeys(columns))
+
+    placeholders = ", ".join(["?" for _ in columns])
+    values = [
+        _normalize_value(parsed_dict.get(column)) if column != "raw_line" else _normalize_value(parsed_dict.get(column))
+        for column in columns
+    ]
+
+    cursor = conn.execute(
+        f"INSERT INTO {table} ({', '.join(columns)}) VALUES ({placeholders})",
+        values,
+    )
+    conn.commit()
+    return cursor.lastrowid
+
+
+def bulk_ingest_from_file(
+    conn: sqlite3.Connection,
+    model: str,
+    report: str,
+    file_path: str | Path,
+) -> int:
+    """Ingerir un archivo de texto línea por línea."""
+
+    normalized_model = model.strip().upper()
+    normalized_report = report.strip().upper()
+    inserted = 0
+    with open(file_path, "r", encoding="utf-8") as fh:
+        for raw_line in fh:
+            raw_line = raw_line.strip()
+            if not raw_line:
+                continue
+            parsed = parse_line(raw_line)
+            if not parsed:
+                continue
+            record: Dict[str, Any] = dict(parsed)
+            record.setdefault("raw_line", raw_line)
+            if insert_parsed_record(conn, normalized_model, normalized_report, record) is not None:
+                inserted += 1
+    return inserted
+
+
+if __name__ == "__main__":
+    connection = init_db(":memory:")
+    print("Tablas creadas:")
+    for model in MODELS:
+        for report in REPORTS:
+            table = _table_name(model, report)
+            print(f" - {table}")

--- a/queclink/specs/__init__.py
+++ b/queclink/specs/__init__.py
@@ -1,6 +1,6 @@
 # Subpaquete para cargar especificaciones de mensajes Queclink.
 """Herramientas relacionadas con esquemas y metadatos de mensajes."""
 
-from .loader import load_spec
+from .loader import get_spec_path
 
-__all__ = ["load_spec"]
+__all__ = ["get_spec_path"]

--- a/tests/test_ingestor_sqlite.py
+++ b/tests/test_ingestor_sqlite.py
@@ -1,0 +1,61 @@
+"""Pruebas para el ingestor SQLite."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from queclink.ingestor_sqlite import bulk_ingest_from_file, init_db
+
+GTERI_SAMPLE = (
+    "+RESP:GTERI,6E1203,864696060004173,GV310LAU,00000100,,10,1,1,0.0,0,115.8,"
+    "117.129356,31.839248,20230808061540,0460,0001,DF5C,05FE6667,03,15,,4.0,"
+    "0000102:34:33,14549,42,11172,100,210000,0,1,0,06,12,0,001A42A2,0617,TMPS,"
+    "08351B00043C,1,26,65,20231030085704,20231030085704,0017$"
+)
+
+
+def _write_lines(tmp_path: Path, filename: str, lines: list[str]) -> Path:
+    path = tmp_path / filename
+    path.write_text("\n".join(lines), encoding="utf-8")
+    return path
+
+
+def test_bulk_ingest_gteri(tmp_path: Path) -> None:
+    conn = init_db(":memory:")
+
+    gv310_path = _write_lines(
+        tmp_path,
+        "gv310_gteri.txt",
+        [GTERI_SAMPLE, "INVALID", ""],
+    )
+    inserted = bulk_ingest_from_file(conn, "GV310LAU", "GTERI", gv310_path)
+    assert inserted == 1
+    cur = conn.execute("SELECT COUNT(*) FROM gv310lau_gteri")
+    assert cur.fetchone()[0] == 1
+
+    gv58_resp = GTERI_SAMPLE.replace("GV310LAU", "GV58LAU")
+    gv58_buff = gv58_resp.replace("+RESP:", "+BUFF:", 1)
+    gv58_path = _write_lines(tmp_path, "gv58_gteri.txt", [gv58_resp, gv58_buff])
+    inserted = bulk_ingest_from_file(conn, "GV58LAU", "GTERI", gv58_path)
+    assert inserted == 2
+    cur = conn.execute("SELECT COUNT(*) FROM gv58lau_gteri")
+    assert cur.fetchone()[0] == 2
+
+
+def test_bulk_ingest_gtinf(tmp_path: Path) -> None:
+    conn = init_db(":memory:")
+
+    gtinf_resp = (
+        "+RESP:GTINF,040201,864696060004173,GV350CEU,GV350CEU,GV350CEU,"
+        "040201,20231030085704,0017$"
+    )
+    gtinf_buff = gtinf_resp.replace("+RESP:", "+BUFF:", 1)
+    gtinf_path = _write_lines(
+        tmp_path,
+        "gv350_gtinf.txt",
+        [gtinf_resp, gtinf_buff, "WRONG"],
+    )
+    inserted = bulk_ingest_from_file(conn, "GV350CEU", "GTINF", gtinf_path)
+    assert inserted == 2
+    cur = conn.execute("SELECT COUNT(*) FROM gv350ceu_gtinf")
+    assert cur.fetchone()[0] == 2


### PR DESCRIPTION
## Summary
- add a SQLite ingestor module capable of initializing tables per model/report and inserting parsed Queclink records
- expose the spec path loader so the parser can be imported without errors
- cover RESP and BUFF ingestion flows for GTERI and GTINF with new tests

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e65ae1e148833382810f230a256bdd