### PR TITLE
feat(cli): add queclink_tramas.py CLI for GTINF/GTERI ingestion

### DIFF
--- a/queclink_tramas.py
+++ b/queclink_tramas.py
@@ -1,9 +1,79 @@
 """Shim de compatibilidad para los analizadores de tramas Queclink."""
 
-# DEPRECATION: migrado a queclink.parser
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Iterable, Optional
 
 from queclink.parser import parse_gteri, parse_gtinf, parse_line
+from src.ingestors.sqlite_gtinf import ensure_db, ingest_lines
 
-__all__ = ["parse_line", "parse_gteri", "parse_gtinf"]
+__all__ = ["parse_line", "parse_gteri", "parse_gtinf", "parse_line_to_record"]
+
 
 parse_line_to_record = parse_line
+
+
+def _read_lines(path: Path) -> Iterable[str]:
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            yield line
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Homologador CLI para tramas Queclink GTINF/GTERI",
+    )
+    parser.add_argument(
+        "--in",
+        dest="input",
+        required=True,
+        help="Archivo de texto con las tramas a homologar.",
+    )
+    parser.add_argument(
+        "--out",
+        dest="output",
+        required=True,
+        help="Ruta donde se almacenará la base de datos SQLite resultante.",
+    )
+    parser.add_argument(
+        "--message",
+        dest="message",
+        choices=["GTINF", "GTERI"],
+        help="Filtrar el procesamiento solo a un tipo de trama específico.",
+    )
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    input_path = Path(args.input)
+    output_path = Path(args.output)
+    message_filter = args.message
+
+    if not input_path.exists():
+        print(f"[ERROR] No se encontró el archivo de entrada: {input_path}", file=sys.stderr)
+        return 1
+
+    print(f"[INFO] Creando base de datos en {output_path}")
+    conn = ensure_db(output_path)
+
+    print(f"[INFO] Procesando tramas desde {input_path}")
+    if message_filter:
+        print(f"[INFO] Filtrando únicamente tramas {message_filter}")
+
+    try:
+        inserted = ingest_lines(conn, _read_lines(input_path), message=message_filter)
+    finally:
+        conn.close()
+
+    print(f"[OK] {inserted} tramas insertadas en {output_path}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - compatibilidad CLI
+    sys.exit(main())

--- a/src/ingestors/__init__.py
+++ b/src/ingestors/__init__.py
@@ -1,0 +1,5 @@
+"""Módulos de ingesta para homologador Queclink."""
+
+from .sqlite_gtinf import ensure_db, ingest_lines  # noqa: F401
+
+__all__ = ["ensure_db", "ingest_lines"]

--- a/src/ingestors/sqlite_gtinf.py
+++ b/src/ingestors/sqlite_gtinf.py
@@ -1,0 +1,78 @@
+"""Utilidades para crear e ingerir tramas en SQLite."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Iterable, Optional
+
+from queclink.ingestor_sqlite import insert_parsed_record, init_db
+
+from queclink.parser import parse_line
+
+
+def ensure_db(path: str | Path) -> sqlite3.Connection:
+    """Crear (si es necesario) una base de datos SQLite para las tramas."""
+
+    db_path = Path(path)
+    if db_path != Path(":memory:"):
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+    return init_db(str(db_path))
+
+
+def ingest_lines(
+    conn: sqlite3.Connection,
+    lines: Iterable[str],
+    *,
+    message: Optional[str] = None,
+) -> int:
+    """Ingerir líneas preparseadas en la base de datos.
+
+    Args:
+        conn: Conexión SQLite devuelta por :func:`ensure_db`.
+        lines: Iterable de líneas crudas (strings).
+        message: Opcional, filtra por tipo de reporte ("GTINF" o "GTERI").
+
+    Returns:
+        Número de tramas insertadas en la base de datos.
+    """
+
+    expected_report = message.upper() if message else None
+    inserted = 0
+
+    for raw_line in lines:
+        line = raw_line.strip()
+        if not line:
+            continue
+
+        parsed = parse_line(line)
+        if not parsed:
+            continue
+
+        report = str(parsed.get("report") or "").upper()
+        if expected_report and report != expected_report:
+            continue
+        if not report:
+            continue
+
+        device = (
+            parsed.get("model")
+            or parsed.get("device")
+            or parsed.get("device_name")
+        )
+        if not device:
+            continue
+
+        normalized_device = str(device).upper()
+        record = dict(parsed)
+        record.setdefault("raw_line", line)
+        record.setdefault("device", normalized_device)
+        record.setdefault("model", normalized_device)
+
+        if insert_parsed_record(conn, normalized_device, report, record) is not None:
+            inserted += 1
+
+    return inserted
+
+
+__all__ = ["ensure_db", "ingest_lines"]


### PR DESCRIPTION
## Summary
- add a CLI entrypoint to `queclink_tramas.py` to ingest GTINF/GTERI traces into SQLite databases
- provide reusable helpers under `src/ingestors` to create the SQLite DB and insert parsed lines

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'tests.common')*

------
https://chatgpt.com/codex/tasks/task_e_68e68df10c948333990470949184fcba