### PR TITLE
Fix SQLite insert statement formatting

### DIFF
--- a/queclink/ingestor_sqlite.py
+++ b/queclink/ingestor_sqlite.py
@@ -64,10 +64,9 @@ class SQLiteIngestor:
         columns = [field.name for field in fields]
         placeholders = ", ".join(["?"] * len(columns))
         values = [_normalize_value(record.get(column)) for column in columns]
-        self.connection.execute(
-            f"INSERT INTO {table} ({', '.join(f'"{col}"' for col in columns)}) VALUES ({placeholders})",
-            values,
-        )
+        column_names = ", ".join(f'"{col}"' for col in columns)
+        sql = f"INSERT INTO {table} ({column_names}) VALUES ({placeholders})"
+        self.connection.execute(sql, values)
         self.connection.commit()
 
     def _table_columns(self, table: str) -> set[str]:


### PR DESCRIPTION
## Summary
- build the INSERT column list separately before executing the SQLite statement to avoid nested f-string parsing issues

## Testing
- pytest *(fails: existing import errors in queclink.messages and bulk_ingest_from_file)*

------
https://chatgpt.com/codex/tasks/task_e_68e7eec730b08333b6c1a2217e2aabe2