### PR TITLE
Add GTERI mask coverage and schema integration tests

### DIFF
--- a/tests/integration/test_cli_gteri_schema_by_model.py
+++ b/tests/integration/test_cli_gteri_schema_by_model.py
@@ -1,0 +1,61 @@
+import sqlite3
+import subprocess
+from pathlib import Path
+
+import pytest
+
+TABLE_BY_MODEL = {
+    "gv350ceu": "gteri_gv350ceu",
+    "gv58lau": "gteri_gv58lau",
+    "gv310lau": "gteri_gv310lau",
+}
+
+MODEL_IMEI = {
+    "gv350ceu": "86252406",
+    "gv58lau": "86631406",
+    "gv310lau": "86858906",
+}
+
+
+@pytest.mark.parametrize(
+    "model,eri_mask,pos_mask",
+    [
+        ("gv350ceu", "00000002", "01"),
+        ("gv58lau", "00000000", "00"),
+        ("gv310lau", "00002000", "00"),
+    ],
+)
+def test_schema_only_yaml_fields(model, eri_mask, pos_mask, tmp_path: Path):
+    imei_prefix = MODEL_IMEI[model]
+    text = (
+        f"+RESP:GTERI,740904,{imei_prefix}012345,{model.upper()},"
+        f"{eri_mask},13574,10,1,1,0.0,295,484.3,-70.297988,-23.739877,"
+        "20251009132737,0730,0001,0836,002BEE06,"
+        f"{pos_mask},8,799972.0,0000329:43:11,,,,100,111000,0,0,20251009133001,2B8B$\n"
+    )
+    in_file = tmp_path / "cases.txt"
+    in_file.write_text(text)
+    db_file = tmp_path / "out.db"
+    subprocess.run(
+        [
+            "python",
+            "queclink_tramas.py",
+            "--in",
+            str(in_file),
+            "--out",
+            str(db_file),
+            "--message",
+            "GTERI",
+        ],
+        check=True,
+    )
+    conn = sqlite3.connect(db_file)
+    try:
+        table = TABLE_BY_MODEL[model]
+        cols = [column[1] for column in conn.execute(f"PRAGMA table_info({table})")]
+    finally:
+        conn.close()
+    forbidden = {"raw_line", "is_buff", "prefix"}
+    assert forbidden.isdisjoint(cols)
+    must_have = {"imei", "lon", "lat", "send_time", "eri_mask"}
+    assert must_have.issubset(set(cols))

--- a/tests/messages/test_gteri_generic_by_model.py
+++ b/tests/messages/test_gteri_generic_by_model.py
@@ -1,0 +1,39 @@
+import pytest
+
+from queclink.messages.gteri import parse_gteri
+
+MODEL_IMEI = {
+    "gv350ceu": "86252406",  # CEU
+    "gv58lau": "86631406",  # 58LAU
+    "gv310lau": "86858906",  # 310LAU
+}
+
+
+def make_line(model: str, eri_mask: str, pos_mask: str) -> str:
+    imei = MODEL_IMEI[model] + "012345"
+    return (
+        f"+RESP:GTERI,740904,{imei},{model.upper()},"
+        f"{eri_mask},13574,10,1,1,0.0,295,484.3,-70.297988,-23.739877,"
+        f"20251009132737,0730,0001,0836,002BEE06,{pos_mask},8,799972.0,"
+        f"0000329:43:11,,,,100,111000,0,0,20251009133001,2B8B$"
+    )
+
+
+@pytest.mark.parametrize("model", ["gv350ceu", "gv58lau", "gv310lau"])
+@pytest.mark.parametrize(
+    "eri_mask,pos_mask,expects",
+    [
+        ("00000000", "00", {"onewire": False, "ble": False, "rat": False}),
+        ("00000002", "01", {"onewire": True, "ble": False, "rat": False}),
+        ("00001000", "13", {"onewire": False, "ble": True, "rat": False}),
+        ("00002000", "00", {"onewire": False, "ble": False, "rat": True}),
+    ],
+)
+def test_gteri_masks_by_model(model, eri_mask, pos_mask, expects):
+    line = make_line(model, eri_mask, pos_mask)
+    parsed = parse_gteri(line, device=model.upper())
+    assert all(k in parsed for k in ("imei", "lon", "lat", "send_time"))
+    assert ("onewire_device_count" in parsed) == expects["onewire"]
+    assert any(key.startswith("ble_") for key in parsed) == expects["ble"]
+    present_rat = ("rat" in parsed) or ("band" in parsed)
+    assert present_rat == expects["rat"]


### PR DESCRIPTION
## Summary
- add a parametrized unit test that checks ERI and position masks across the GV350CEU, GV58LAU and GV310LAU parsers
- add an integration test that ensures the SQLite output schema for GTERI messages does not expose non-YAML columns

## Testing
- pytest -q *(fails: existing parser/CLI helpers missing expected exports such as parse_line_to_record, and the current parser output lacks 1-Wire/BLE/RAT markers)*

------
https://chatgpt.com/codex/tasks/task_e_68e810f0e3c48333bd3bd6b07eb7f89c