### PR TITLE
Support ERI mask-driven optional GTERI data

### DIFF
--- a/spec/gv310lau/gteri.yml
+++ b/spec/gv310lau/gteri.yml
@@ -147,6 +147,16 @@ schema:
                   battery_pct: { type: int, min: 0, max: 100, nullable: true }
                   relay_state: { type: int, enum: [0,1], nullable: true }
 
+        - name: rat
+          type: int
+          optional: true
+          when: { mask: eri_mask, bit: 13 }
+
+        - name: band
+          type: string
+          optional: true
+          when: { field_present: rat }
+
     - name: tail
       fields:
         - { name: send_time, type: datetime, format: "YYYYMMDDHHMMSS" }

--- a/spec/gv58lau/gteri.yml
+++ b/spec/gv58lau/gteri.yml
@@ -254,6 +254,16 @@ schema:
               optional: true
               present_if: { mask_field: ble_append_mask, bit: 14 }
 
+        - name: rat
+          type: int
+          optional: true
+          when: { mask: eri_mask, bit: 13 }
+
+        - name: band
+          type: string
+          optional: true
+          when: { field_present: rat }
+
     - name: tail
       fields:
         - { name: send_time, type: datetime, format: "YYYYMMDDHHMMSS" }

--- a/tests/test_parser_when_conditions.py
+++ b/tests/test_parser_when_conditions.py
@@ -1,0 +1,60 @@
+"""Tests for spec-driven conditional parsing helpers."""
+
+from __future__ import annotations
+
+from queclink.parser import Condition, load_spec
+
+
+def _field_map(spec):
+    return {field.name: field for field in spec.fields}
+
+
+def test_gv310_digital_fuel_uses_eri_mask_condition():
+    spec = load_spec("GV310LAU", "GTERI")
+    fields = _field_map(spec)
+    digital_fuel = fields.get("digital_fuel_sensor_data")
+    assert digital_fuel is not None
+    conds = list(digital_fuel.enabled_if_any)
+    assert conds, "digital_fuel_sensor_data should be gated by eri_mask"
+    cond = conds[0]
+    assert isinstance(cond, Condition)
+    assert cond.mask_field == "eri_mask"
+    assert cond.bit == 0
+
+
+def test_gv310_band_depends_on_rat_presence():
+    spec = load_spec("GV310LAU", "GTERI")
+    fields = _field_map(spec)
+    assert "rat" in fields
+    band_field = fields.get("band")
+    assert band_field is not None
+    conds = list(band_field.enabled_if_any)
+    assert conds, "band must depend on rat presence"
+    assert conds[0].field_present == "rat"
+
+
+def test_when_anyof_generates_multiple_conditions():
+    spec = load_spec("GV310LAU", "GTERI")
+    fields = _field_map(spec)
+    fuel_block = fields.get("fuel_sensor_block")
+    assert fuel_block is not None
+    nested = {child.name: child for child in fuel_block.fields}
+    temp_field = nested.get("fuel_temperature_c")
+    assert temp_field is not None
+    any_conditions = list(temp_field.present_if_any)
+    assert len(any_conditions) == 2
+    equals_values = {cond.equals for cond in any_conditions}
+    assert equals_values == {2, 6}
+
+
+def test_gv58_includes_rat_and_band():
+    spec = load_spec("GV58LAU", "GTERI")
+    fields = _field_map(spec)
+    rat_field = fields.get("rat")
+    band_field = fields.get("band")
+    assert rat_field is not None
+    assert band_field is not None
+    rat_cond = list(rat_field.enabled_if_any)
+    assert rat_cond and rat_cond[0].mask_field == "eri_mask"
+    band_cond = list(band_field.enabled_if_any)
+    assert band_cond and band_cond[0].field_present == "rat"


### PR DESCRIPTION
## Summary
- extend the spec loader so `when` clauses map to parser conditions for masks and value equality
- add the optional RAT/Band fields to the GV310LAU and GV58LAU GTERI specs so SQLite tables include those columns
- cover the new behaviour with regression tests that assert the generated conditions for ERI-gated fields

## Testing
- pytest *(fails: missing legacy helpers exported by queclink.parser)*

------
https://chatgpt.com/codex/tasks/task_e_68e828ddd1d483338e0c17ff572d6a07