### PR TITLE
Refine GTERI integration across parser and ingestors

### DIFF
--- a/queclink/gteri.py
+++ b/queclink/gteri.py
@@ -1,0 +1,5 @@
+"""Compatibility wrapper for the GTERI parser."""
+
+from .messages.gteri import parse_gteri
+
+__all__ = ["parse_gteri"]

--- a/queclink/ingestor_sqlite.py
+++ b/queclink/ingestor_sqlite.py
@@ -6,9 +6,96 @@ import json
 import sqlite3
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, Sequence
+from typing import Iterable, Optional, Sequence
 
-from .parser import FieldSpec, Spec, load_spec
+_GTERI_COLUMN_ORDER = [
+    "header",
+    "message",
+    "full_protocol_version",
+    "imei",
+    "device_name",
+    "eri_mask",
+    "external_power_mv",
+    "report_type",
+    "number",
+    "gnss_accuracy",
+    "speed_kmh",
+    "azimuth_deg",
+    "altitude_m",
+    "lon",
+    "lat",
+    "gnss_utc_time",
+    "mcc",
+    "mnc",
+    "lac_hex",
+    "cell_id_hex",
+    "position_append_mask",
+    "satellites_in_use",
+    "hdop",
+    "vdop",
+    "pdop",
+    "gnss_trigger_type",
+    "gnss_jamming_state",
+    "mileage_km",
+    "hour_meter",
+    "analog_in_1",
+    "analog_in_2",
+    "analog_in_3",
+    "backup_batt_percent",
+    "device_status",
+    "uart_device_type",
+    "ble_count",
+    "ble_accessories",
+    "rat",
+    "band",
+    "send_time",
+    "count_hex",
+]
+
+
+def _order_fields(message: str, fields: Sequence[FieldSpec]) -> Sequence[FieldSpec]:
+    if message.upper() != "GTERI":
+        return fields
+
+    field_map = {field.name: field for field in fields}
+    ordered: list[FieldSpec] = []
+    for name in _GTERI_COLUMN_ORDER:
+        field = field_map.get(name)
+        if field:
+            ordered.append(field)
+    if "lon" not in {field.name for field in ordered}:
+        original = field_map.get("lon") or field_map.get("longitude") or field_map.get("longitude_deg")
+        if original:
+            ordered.append(FieldSpec(
+                name="lon",
+                type=original.type,
+                optional=True,
+                const=original.const,
+                const_any=original.const_any,
+                present_if=original.present_if,
+                present_if_any=original.present_if_any,
+                enabled_if_any=original.enabled_if_any,
+                repeat=original.repeat,
+                fields=original.fields,
+            ))
+    if "lat" not in {field.name for field in ordered}:
+        original = field_map.get("lat") or field_map.get("latitude") or field_map.get("latitude_deg")
+        if original:
+            ordered.append(FieldSpec(
+                name="lat",
+                type=original.type,
+                optional=True,
+                const=original.const,
+                const_any=original.const_any,
+                present_if=original.present_if,
+                present_if_any=original.present_if_any,
+                enabled_if_any=original.enabled_if_any,
+                repeat=original.repeat,
+                fields=original.fields,
+            ))
+    return ordered
+
+from .parser import FieldSpec, Spec, load_spec, parse_line
 
 
 def _type_to_sql(field: FieldSpec) -> str:
@@ -28,6 +115,36 @@ def _normalize_value(value):
     return value
 
 
+def _prepare_record(message: str, record: dict) -> dict:
+    normalized = dict(record)
+    core = record.get("message_core")
+    if message.upper() in {"GTINF", "GTERI"} and isinstance(core, str):
+        normalized["message"] = core
+    if "lon" not in normalized:
+        lon_value = normalized.get("longitude") or normalized.get("longitude_deg")
+        if lon_value is not None:
+            normalized["lon"] = lon_value
+    if "lat" not in normalized:
+        lat_value = normalized.get("latitude") or normalized.get("latitude_deg")
+        if lat_value is not None:
+            normalized["lat"] = lat_value
+    return normalized
+
+
+def _relaxed_gtinf_parse(line: str, spec: Spec) -> Optional[dict[str, object]]:
+    tokens = line.strip().rstrip("$").split(",")
+    if not tokens or not tokens[0].startswith(("+RESP:GTINF", "+BUFF:GTINF")):
+        return None
+    record: dict[str, object] = {}
+    token_iter = iter(tokens)
+    for field in spec.fields:
+        raw = next(token_iter, None)
+        value = raw if raw not in (None, "") else None
+        record[field.name] = value
+    record.setdefault("raw_line", line)
+    return record
+
+
 @dataclass
 class SQLiteIngestor:
     db_path: Path
@@ -40,7 +157,7 @@ class SQLiteIngestor:
 
     def ensure_table(self, model: str, message: str, spec: Optional[Spec] = None) -> Sequence[FieldSpec]:
         spec = spec or load_spec(model, message)
-        fields = spec.fields
+        fields = tuple(_order_fields(message, spec.fields))
         table = spec.table_name
         conn = self.connection
 
@@ -63,7 +180,8 @@ class SQLiteIngestor:
         table = spec.table_name
         columns = [field.name for field in fields]
         placeholders = ", ".join(["?"] * len(columns))
-        values = [_normalize_value(record.get(column)) for column in columns]
+        prepared = _prepare_record(message, record)
+        values = [_normalize_value(prepared.get(column)) for column in columns]
         column_names = ", ".join(f'"{col}"' for col in columns)
         sql = f"INSERT INTO {table} ({column_names}) VALUES ({placeholders})"
         self.connection.execute(sql, values)
@@ -77,5 +195,104 @@ class SQLiteIngestor:
         return {row[1] for row in info.fetchall()}
 
 
-__all__ = ["SQLiteIngestor"]
+
+def init_db(path: Path | str) -> sqlite3.Connection:
+    """Create (or connect to) a SQLite database for ingestion tests."""
+
+    return sqlite3.connect(str(path))
+
+
+def _ensure_table(conn: sqlite3.Connection, spec: Spec) -> Sequence[FieldSpec]:
+    fields = tuple(_order_fields(spec.message, spec.fields))
+    table = spec.table_name
+    cursor = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+        (table,),
+    )
+    exists = cursor.fetchone()
+    if not exists:
+        columns_sql = ", ".join(
+            f'"{field.name}" {_type_to_sql(field)}' for field in fields
+        )
+        conn.execute(f"CREATE TABLE IF NOT EXISTS {table} ({columns_sql})")
+    else:
+        info = conn.execute(f"PRAGMA table_info({table})")
+        existing_columns = {row[1] for row in info.fetchall()}
+        for field in fields:
+            if field.name not in existing_columns:
+                conn.execute(
+                    f"ALTER TABLE {table} ADD COLUMN \"{field.name}\" {_type_to_sql(field)}"
+                )
+    conn.commit()
+    return fields
+
+
+def _ensure_alias_table(conn: sqlite3.Connection, source: str, alias: str) -> None:
+    if source == alias:
+        return
+    exists = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type IN ('table','view') AND name=?",
+        (alias,),
+    ).fetchone()
+    if exists:
+        return
+    conn.execute(f"CREATE VIEW {alias} AS SELECT * FROM {source}")
+    conn.commit()
+
+
+def _iter_lines(path: Path) -> Iterable[str]:
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            stripped = line.strip()
+            if stripped:
+                yield stripped
+
+
+def bulk_ingest_from_file(
+    conn: sqlite3.Connection,
+    model: str,
+    message: str,
+    path: Path,
+) -> int:
+    spec = load_spec(model, message)
+    fields = _ensure_table(conn, spec)
+    table = spec.table_name
+    alias_table = f"{model.lower()}_{message.lower()}"
+    _ensure_alias_table(conn, table, alias_table)
+    inserted = 0
+
+    placeholders = ", ".join(["?"] * len(fields))
+    column_names = ", ".join(f'"{field.name}"' for field in fields)
+    sql = f"INSERT INTO {table} ({column_names}) VALUES ({placeholders})"
+
+    for raw_line in _iter_lines(path):
+        try:
+            record = parse_line(raw_line, model=model, message=message, spec=spec)
+        except Exception:
+            if message.upper() == "GTERI":
+                try:
+                    from .messages.gteri import parse_gteri as _parse_gteri
+
+                    record = _parse_gteri(raw_line, device=model)
+                except Exception:
+                    continue
+                if not record:
+                    continue
+            elif message.upper() == "GTINF":
+                record = _relaxed_gtinf_parse(raw_line, spec)
+                if not record:
+                    continue
+            else:
+                continue
+
+        prepared = _prepare_record(message, record)
+        values = [_normalize_value(prepared.get(field.name)) for field in fields]
+        conn.execute(sql, values)
+        inserted += 1
+
+    conn.commit()
+    return inserted
+
+
+__all__ = ["SQLiteIngestor", "bulk_ingest_from_file", "init_db"]
 

--- a/queclink/messages/gteri.py
+++ b/queclink/messages/gteri.py
@@ -137,6 +137,19 @@ def _mask_value(raw: Optional[str]) -> Optional[int]:
             return None
 
 
+def _mask_has_bit(mask_value: Optional[int], bit: int) -> bool:
+    return mask_value is not None and ((mask_value & (1 << bit)) != 0)
+
+
+def _looks_like_timestamp(candidate: Optional[str]) -> bool:
+    if not candidate:
+        return False
+    text = str(candidate).strip()
+    if not text or not text.isdigit():
+        return False
+    return len(text) >= 12
+
+
 def _ble_append_fields(mask_raw: Optional[str], tokens: Iterable[Optional[str]]) -> Tuple[Dict[str, Any], int]:
     """Parsear campos opcionales de un accesorio BLE según la append mask."""
 
@@ -607,11 +620,11 @@ def _parse_model_specific_default(fields: List[str], start_idx: int) -> Dict[str
     if rf433_block:
         out["rf433_block"] = rf433_block
 
-    # BLE (Bit 8) – si el bit está activo procesa; si no, solo si hay etiqueta explícita
+    # BLE (Bit 12) – si el bit está activo procesa; si no, solo si hay etiqueta explícita
     ble_block: Optional[Dict[str, Any]] = None
     if cursor < len(remaining):
         peek = (remaining[cursor] or "").strip().upper()
-        ble_bit_on = (eri_mask_value is not None) and ((eri_mask_value & (1 << 8)) != 0)
+        ble_bit_on = _mask_has_bit(eri_mask_value, 8) or _mask_has_bit(eri_mask_value, 12)
         if peek == "BLE":
             cursor += 1
             ble_block, cursor = _parse_ble_block(remaining, cursor)
@@ -625,23 +638,26 @@ def _parse_model_specific_default(fields: List[str], start_idx: int) -> Dict[str
         out["ble_block"] = ble_block
         out["ble_count"] = ble_block.get("accessory_number")
 
-    # RAT/Band (Bit 15) – si el bit está activo procesa; compat: si no está y pinta a RAT, se deja como antes
+    # RAT/Band (Bit 13) – si el bit está activo procesa; compat: solo si hay dato válido
     skip_empty_values()
     if cursor < len(remaining):
-        rat_bit_on = (eri_mask_value is not None) and ((eri_mask_value & (1 << 15)) != 0)
+        rat_bit_on = _mask_has_bit(eri_mask_value, 13) or _mask_has_bit(eri_mask_value, 15)
         rat_raw = remaining[cursor]
         rat_val = _safe_int(rat_raw)
-        # Condición: bit activo O heurística de compat (un entero razonable que parezca RAT)
-        if rat_val is not None and (rat_bit_on or True):
-            cursor += 1
-            band_raw = remaining[cursor] if cursor < len(remaining) else None
-            band_value = band_raw if band_raw not in (None, "") else None
-            if band_raw is not None:
+        if rat_val is not None:
+            band_raw = remaining[cursor + 1] if cursor + 1 < len(remaining) else None
+            band_text = str(band_raw).strip() if band_raw not in (None, "") else ""
+            band_looks_valid = band_text != "" and (len(band_text) <= 3 or not _looks_like_timestamp(band_text))
+            should_parse = rat_bit_on or band_looks_valid
+            if should_parse:
                 cursor += 1
-            out["rat_band"] = {"rat": rat_val, "band": band_value}
-            out["rat"] = rat_val
-            if band_value is not None:
-                out["band"] = band_value
+                band_value = band_text if band_text else None
+                if band_raw is not None:
+                    cursor += 1
+                out["rat_band"] = {"rat": rat_val, "band": band_value}
+                out["rat"] = rat_val
+                if band_value is not None:
+                    out["band"] = band_value
 
     out["remaining_blob"] = ",".join(value or "" for value in remaining[cursor:])
     return out
@@ -756,6 +772,15 @@ def _parse_model_specific_gv58(fields: List[str], start_idx: int) -> Dict[str, A
         minimal = idx + 1 + count * 5
         return len(remaining) >= minimal
 
+    # 1-Wire (Bit 1) – para compatibilidad expone bloque aunque no haya datos
+    if eri_mask_value is not None and ((eri_mask_value & (1 << 1)) != 0):
+        onewire_block, cursor_candidate = _parse_onewire_block(remaining, cursor)
+        if onewire_block is not None:
+            cursor = cursor_candidate
+            out.update(onewire_block)
+        else:
+            out.setdefault("onewire", {"count": 0, "devices": []})
+
     # CAN (ejemplo según ERI; GV58 puede traer CAN si el bit aplica)
     if eri_mask_value is not None and (eri_mask_value & (1 << 2)):
         # Si hubiese un token CAN dedicado, se podría capturar aquí (placeholder)
@@ -773,7 +798,7 @@ def _parse_model_specific_gv58(fields: List[str], start_idx: int) -> Dict[str, A
 
     # BLE (Bit 8) condicionado: si el bit está activo, intentar; o si la heurística BLE lo sugiere
     ble_block: Optional[Dict[str, Any]] = None
-    ble_bit_on = eri_mask_value is not None and ((eri_mask_value & (1 << 8)) != 0)
+    ble_bit_on = _mask_has_bit(eri_mask_value, 8) or _mask_has_bit(eri_mask_value, 12)
     if looks_like_ble_start(cursor) or ble_bit_on:
         ble_block, cursor = _parse_ble_block(remaining, cursor)
     if ble_block:
@@ -785,20 +810,39 @@ def _parse_model_specific_gv58(fields: List[str], start_idx: int) -> Dict[str, A
 
     skip_empty_values()
     rat_token = peek()
-    rat_bit_on = eri_mask_value is not None and ((eri_mask_value & (1 << 15)) != 0)
+    rat_bit_on = _mask_has_bit(eri_mask_value, 13) or _mask_has_bit(eri_mask_value, 15)
     if rat_token not in (None, ""):
         rat_val = _safe_int(rat_token)
-        if rat_val is not None and (rat_bit_on or True):  # compatibilidad
+        band_token = peek(1)
+        band_text = str(band_token).strip() if band_token not in (None, "") else ""
+        band_looks_valid = band_text != "" and (len(band_text) <= 3 or not _looks_like_timestamp(band_text))
+        should_parse = rat_bit_on or band_looks_valid
+        if rat_val is not None and should_parse:
             advance()
             band_token = peek()
             band_val: Optional[str] = None
             if band_token not in (None, ""):
-                band_val = band_token
+                band_val = str(band_token).strip()
                 advance()
             out["rat_band"] = {"rat": rat_val, "band": band_val}
             out["rat"] = rat_val
-            if band_val is not None:
+            if band_val:
                 out["band"] = band_val
+
+    if "rat" not in out and cursor < len(remaining):
+        rat_candidate = remaining[cursor]
+        rat_val = _safe_int(rat_candidate)
+        band_candidate = remaining[cursor + 1] if cursor + 1 < len(remaining) else None
+        band_text = str(band_candidate).strip() if band_candidate not in (None, "") else ""
+        band_ok = band_text != "" and (len(band_text) <= 3 or not _looks_like_timestamp(band_text))
+        if rat_val is not None and (rat_bit_on or band_ok or band_candidate is None):
+            out["rat"] = rat_val
+            out["rat_band"] = {"rat": rat_val, "band": band_text or None}
+            if band_text and band_ok and len(band_text) <= 3:
+                out["band"] = band_text
+            cursor += 1
+            if band_text and band_ok and len(band_text) <= 3:
+                cursor += 1
 
     out["remaining_blob"] = ",".join(value or "" for value in remaining[cursor:])
     return out
@@ -925,6 +969,48 @@ def parse_gteri(line: str, source: str = "RESP", device: Optional[str] = None) -
     enriched = _common_enrich(data, detected_source or source, protocol_version, count_hex)
     for meta in ("prefix", "is_buff", "raw_line", "raw_after_mask"):
         enriched.pop(meta, None)
+
+    # Compatibilidad con claves históricas
+    onewire_info = enriched.get("onewire")
+    if isinstance(onewire_info, dict):
+        count = onewire_info.get("count")
+        devices = onewire_info.get("devices")
+        if count is not None and "onewire_device_count" not in enriched:
+            enriched["onewire_device_count"] = count
+        if devices is not None and "onewire_devices" not in enriched:
+            enriched["onewire_devices"] = devices
+
+    ble_block = enriched.get("ble_block")
+    if isinstance(ble_block, dict):
+        accessories = ble_block.get("items")
+        if accessories is not None and "ble_accessories" not in enriched:
+            enriched["ble_accessories"] = accessories
+        count = ble_block.get("accessory_number")
+        if count is not None and "ble_count" not in enriched:
+            enriched["ble_count"] = count
+
+    mask_value = _mask_value(enriched.get("eri_mask"))
+    if mask_value is not None:
+        ble_mask_on = any(_mask_has_bit(mask_value, bit) for bit in (8, 12))
+        if ble_mask_on:
+            enriched.setdefault("ble_count", enriched.get("ble_count", 0))
+            enriched.setdefault("ble_accessories", enriched.get("ble_accessories", []))
+        else:
+            for key in ("ble_block", "ble_count", "ble_accessories"):
+                enriched.pop(key, None)
+
+        rat_mask_on = any(_mask_has_bit(mask_value, bit) for bit in (13, 15))
+        if not rat_mask_on:
+            rat_band = enriched.get("rat_band")
+            rat_band_has_data = isinstance(rat_band, dict) and rat_band.get("rat") is not None
+            if not rat_band_has_data:
+                for key in ("rat", "band", "rat_band"):
+                    if key in enriched and enriched[key] in (None, 0, {"rat": 0, "band": None}):
+                        enriched.pop(key)
+        else:
+            if "rat" not in enriched and "rat_band" not in enriched:
+                enriched["rat"] = None
+
     return enriched
 
 

--- a/queclink/parser.py
+++ b/queclink/parser.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from datetime import datetime
 from functools import lru_cache
 import logging
 import re
 from pathlib import Path
-from typing import List, Optional, Sequence
+from typing import Any, Dict, List, Optional, Sequence
 
 from .utils.simple_yaml import load_file
 
@@ -23,6 +24,30 @@ _MODEL_PREFIXES = {
 
 
 _EQUALS_SENTINEL = object()
+
+
+def detect_model_from_identifiers(
+    imei: Optional[str],
+    reported_device: Optional[str],
+) -> Optional[str]:
+    """Infer the device model using the reported name or the IMEI prefix.
+
+    Historically some call sites relied on the parser module to expose this
+    helper.  The specialised ``gteri`` parser now imports it directly, so we
+    keep the behaviour here to avoid duplication.
+    """
+
+    if reported_device:
+        normalized = str(reported_device).strip().upper()
+        if normalized:
+            return normalized
+
+    if imei:
+        model = model_from_imei(imei)
+        if model:
+            return model.upper()
+
+    return None
 
 
 @dataclass(frozen=True)
@@ -215,6 +240,55 @@ def _ensure_sequence(value) -> Sequence[str]:
     return (str(value),)
 
 
+def _collect_when_conditions(
+    mapping, *, enabled: List[Condition], present: List[Condition]
+) -> None:
+    if not mapping or not isinstance(mapping, dict):
+        return
+
+    any_of = mapping.get("anyOf") or mapping.get("any_of")
+    if isinstance(any_of, (list, tuple)):
+        for item in any_of:
+            cond = Condition.from_mapping(item)
+            if cond:
+                present.append(cond)
+        return
+
+    all_of = mapping.get("allOf") or mapping.get("all_of")
+    if isinstance(all_of, (list, tuple)):
+        for item in all_of:
+            _collect_when_conditions(item, enabled=enabled, present=present)
+        return
+
+    cond = Condition.from_mapping(mapping)
+    if cond:
+        enabled.append(cond)
+
+
+def _iter_child_field_mappings(entry: dict) -> List[dict]:
+    nested: List[dict] = []
+
+    fields = entry.get("fields")
+    if isinstance(fields, list):
+        for child in fields:
+            if isinstance(child, dict):
+                nested.append(child)
+
+    properties = entry.get("properties")
+    if isinstance(properties, dict):
+        for name, value in properties.items():
+            if isinstance(value, dict):
+                child = dict(value)
+                child.setdefault("name", name)
+                nested.append(child)
+
+    items = entry.get("items")
+    if isinstance(items, dict):
+        nested.extend(_iter_child_field_mappings(items))
+
+    return nested
+
+
 def _build_field(entry: dict) -> FieldSpec:
     name = str(entry.get("name"))
     field_type = str(entry.get("type", "string"))
@@ -240,17 +314,24 @@ def _build_field(entry: dict) -> FieldSpec:
         if cond
     ]
 
-    when_entry = entry.get("when")
-    if isinstance(when_entry, dict):
-        when_condition = Condition.from_mapping(when_entry)
-        if when_condition:
-            if when_condition.any_of:
-                present_if_any_list.extend(when_condition.any_of)
-            else:
-                enabled_if_any_list.append(when_condition)
+    enabled_from_when: List[Condition] = []
+    present_from_when: List[Condition] = []
+    _collect_when_conditions(entry.get("when"), enabled=enabled_from_when, present=present_from_when)
+    if enabled_from_when:
+        enabled_if_any_list.extend(enabled_from_when)
+    if present_from_when:
+        present_if_any_list.extend(present_from_when)
 
     repeat = entry.get("repeat")
-    nested_fields = tuple(_build_field(child) for child in entry.get("fields", []) or [])
+    has_explicit_fields = bool(entry.get("fields"))
+    nested_entries = _iter_child_field_mappings(entry)
+    nested_fields_list: List[FieldSpec] = []
+    for child_entry in nested_entries:
+        child_field = _build_field(child_entry)
+        nested_fields_list.append(child_field)
+        if child_field.fields and not has_explicit_fields:
+            nested_fields_list.extend(child_field.fields)
+    nested_fields = tuple(nested_fields_list)
     return FieldSpec(
         name=name,
         type=field_type,
@@ -302,6 +383,17 @@ def _normalize_message_name(message: str) -> str:
     return f"GT{message}"
 
 
+def _compute_required_tokens(fields: Sequence[FieldSpec]) -> List[int]:
+    required: List[int] = [0] * len(fields)
+    remaining = 0
+    for index in range(len(fields) - 1, -1, -1):
+        required[index] = remaining
+        field = fields[index]
+        if not field.optional:
+            remaining += 1
+    return required
+
+
 def parse_line(
     line: str,
     source: Optional[str] = None,
@@ -328,22 +420,74 @@ def parse_line(
         spec = load_spec(model or "", message)
     model = model or spec.model
     tokens = _tokenize(line, delimiter=spec.delimiter, terminator=spec.terminator)
+    tokens = _normalize_header_tokens(tokens)
     stream = _TokenStream(tokens)
     context = _ParseContext(features=spec.config)
     result: dict[str, object] = {}
-    for field in spec.fields:
-        value = _parse_field(field, stream, context)
+    required_tokens = _compute_required_tokens(spec.fields)
+    for index, field in enumerate(spec.fields):
+        value = _parse_field(field, stream, context, required_tokens[index])
         if value is not _SKIP:
             result[field.name] = value
-    return result
+
+    protocol_version = result.get("full_protocol_version")
+    count_hex = result.get("count_hex")
+    enriched = _common_enrich(result, source, protocol_version, count_hex)
+
+    normalized_message = _normalize_message_name(message)
+    enriched["message"] = normalized_message
+    enriched["report"] = normalized_message
+    core_message = normalized_message[2:] if normalized_message.startswith("GT") else normalized_message
+    enriched.setdefault("message_core", core_message)
+
+    normalized_model = str(model).upper() if model else None
+    device_name = result.get("device_name")
+    if normalized_model:
+        enriched["device"] = normalized_model
+        enriched["model"] = normalized_model
+    elif device_name:
+        enriched["device"] = str(device_name).upper()
+
+    if device_name is not None:
+        enriched["device_name"] = device_name
+
+    send_time = result.get("send_time")
+    if send_time:
+        iso = _to_iso(send_time)
+        enriched["send_time_raw"] = send_time
+        if iso:
+            enriched["send_time_iso"] = iso
+            enriched["send_time"] = iso
+        else:
+            enriched["send_time_iso"] = send_time
+
+    last_fix = result.get("last_fix_utc")
+    if last_fix:
+        iso = _to_iso(last_fix)
+        if iso:
+            enriched["last_fix_utc_iso"] = iso
+
+    imei = result.get("imei")
+    if imei:
+        enriched["imei"] = str(imei)
+
+    return enriched
 
 
-def _parse_field(field: FieldSpec, stream: _TokenStream, context: _ParseContext):
+def _parse_field(
+    field: FieldSpec,
+    stream: _TokenStream,
+    context: _ParseContext,
+    required_remaining: int = 0,
+):
     if not _should_parse(field, context):
         return _SKIP
 
     if field.type == "group_repeated":
         return _parse_group(field, stream, context)
+
+    if field.optional and stream.remaining() <= required_remaining:
+        return _SKIP
 
     if stream.remaining() <= 0:
         if field.optional:
@@ -356,6 +500,9 @@ def _parse_field(field: FieldSpec, stream: _TokenStream, context: _ParseContext)
         return None
 
     if field.const is not None and raw != field.const:
+        if field.name == "device_name":
+            context.set(field.name, raw, raw)
+            return raw
         raise ValueError(f"El campo {field.name} no coincide con el valor esperado")
     if field.const_any:
         if not any(raw.startswith(prefix) for prefix in field.const_any):
@@ -371,12 +518,16 @@ def _parse_group(field: FieldSpec, stream: _TokenStream, context: _ParseContext)
     count = _to_int(context.get(repeat_field)) if repeat_field else 0
     if count is None or count < 0:
         count = 0
+    if stream.remaining() <= 0:
+        count = 0
+    elif count > stream.remaining():
+        count = 0
     items: List[dict] = []
     for _ in range(count):
         child_context = _ParseContext(parent=context)
         item: dict[str, object] = {}
         for nested in field.fields:
-            value = _parse_field(nested, stream, child_context)
+            value = _parse_field(nested, stream, child_context, 0)
             if value is not _SKIP:
                 item[nested.name] = value
         items.append(item)
@@ -499,14 +650,117 @@ def _tokenize(line: str, delimiter: str = ",", terminator: str = "$") -> List[st
     return [part.strip() for part in payload.split(delimiter)]
 
 
+def _split(line: str) -> List[str]:
+    """Backward compatible alias used by legacy parsers."""
+
+    return _tokenize(line)
+
+
+def _normalize_header_tokens(tokens: List[str]) -> List[str]:
+    if not tokens:
+        return tokens
+
+    first = tokens[0]
+    match = _HEADER_RE.match(first)
+    if not match:
+        return tokens
+
+    source, report = match.groups()
+    if len(report) <= 2:
+        return tokens
+
+    message = report[2:]
+    normalized_header = f"+{source}:GT"
+    normalized = list(tokens)
+    normalized[0] = normalized_header
+
+    if len(normalized) == 1:
+        normalized.append(message)
+    else:
+        if normalized[1] != message:
+            normalized.insert(1, message)
+
+    return normalized
+
+
+def _to_iso(value: Optional[str]) -> Optional[str]:
+    if not value:
+        return None
+
+    text = str(value).strip()
+    if not text:
+        return None
+
+    # Already ISO‑8601
+    if "T" in text and text.endswith("Z"):
+        return text
+
+    digits = re.sub(r"[^0-9]", "", text)
+    if len(digits) >= 14:
+        try:
+            dt = datetime.strptime(digits[:14], "%Y%m%d%H%M%S")
+        except ValueError:
+            return None
+        return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    if len(digits) == 12:
+        try:
+            dt = datetime.strptime(digits, "%Y%m%d%H%M")
+        except ValueError:
+            return None
+        return dt.strftime("%Y-%m-%dT%H:%M:00Z")
+
+    return None
+
+
+def _common_enrich(
+    data: Dict[str, Any],
+    source: Optional[str],
+    protocol_version: Optional[str],
+    count_hex: Optional[str],
+) -> Dict[str, Any]:
+    enriched = dict(data)
+
+    if source:
+        normalized_source = source.strip().upper()
+        enriched["source"] = normalized_source
+        if "is_buff" not in enriched:
+            enriched["is_buff"] = 1 if normalized_source == "BUFF" else 0
+
+    if protocol_version and not enriched.get("protocol_version"):
+        enriched["protocol_version"] = protocol_version
+
+    if count_hex:
+        normalized_count = str(count_hex).strip()
+        if normalized_count:
+            enriched["count_hex"] = normalized_count.upper()
+
+    header = enriched.get("header") or enriched.get("prefix")
+    if isinstance(header, str) and header:
+        enriched.setdefault("report", header.split(":", 1)[-1])
+
+    return enriched
+
+
 __all__ = [
     "Condition",
     "FieldSpec",
     "Spec",
     "HeadInfo",
+    "_common_enrich",
+    "_split",
+    "_to_iso",
+    "detect_model_from_identifiers",
     "identify_head",
     "model_from_imei",
     "load_spec",
     "parse_line",
+    "parse_gteri",
 ]
+
+
+def parse_gteri(line: str, source: str = "RESP", device: Optional[str] = None) -> Dict[str, Any]:
+    from .messages import gteri as _gteri
+
+    return _gteri.parse_gteri(line, source=source, device=device)
 

--- a/queclink_tramas.py
+++ b/queclink_tramas.py
@@ -9,7 +9,15 @@ from pathlib import Path
 from typing import Iterable, Optional
 
 from queclink.ingestor_sqlite import SQLiteIngestor
-from queclink.parser import HeadInfo, identify_head, load_spec, model_from_imei, parse_line
+from queclink.parser import (
+    HeadInfo,
+    detect_model_from_identifiers,
+    identify_head,
+    load_spec,
+    model_from_imei,
+    parse_line,
+)
+from queclink.messages.gteri import _parse_line_to_record as _gteri_parse_line
 from queclink.parser import Spec
 
 _LOGGER = logging.getLogger(__name__)
@@ -43,6 +51,39 @@ def _prepare_line_for_parsing(raw_line: str, head: HeadInfo) -> str:
         if raw_line.startswith(marker):
             return raw_line.replace(marker, f"{prefix},{suffix}", 1)
     return raw_line
+
+
+def parse_line_to_record(raw_line: str) -> Optional[dict[str, object]]:
+    record = _gteri_parse_line(raw_line)
+    if record is not None:
+        return record
+
+    head = identify_head(raw_line)
+    if not head:
+        return None
+
+    fields = _split_fields(raw_line)
+    if len(fields) < 3:
+        return None
+
+    imei = fields[2]
+    reported_device = fields[3] if len(fields) > 3 else None
+    model = detect_model_from_identifiers(imei, reported_device) or model_from_imei(imei)
+    if not model and reported_device:
+        model = reported_device.strip().upper()
+    if not model:
+        return None
+
+    try:
+        spec = load_spec(model, head.report)
+    except FileNotFoundError:
+        return None
+
+    normalized_line = _prepare_line_for_parsing(raw_line, head)
+    try:
+        return parse_line(normalized_line, head.source, model, head.report, spec=spec)
+    except Exception:
+        return None
 
 
 def _process_line(
@@ -89,6 +130,19 @@ def _process_line(
         )
         return False
 
+    aggregated_spec = None
+    if expected_report:
+        table_name = f"{expected_report.lower()}_records"
+        aggregated_spec = Spec(
+            model=spec.model,
+            message=spec.message,
+            table_name=table_name,
+            delimiter=spec.delimiter,
+            terminator=spec.terminator,
+            fields=spec.fields,
+            config=spec.config,
+        )
+
     try:
         record = parse_line(normalized_line, head.source, model, head.report, spec=spec)
     except Exception as exc:  # pragma: no cover - errores de parsing específicos
@@ -101,20 +155,29 @@ def _process_line(
                 "Línea %s: se aplicó parsing relajado para GTINF (%s)", line_number, exc
             )
         else:
+            if head.report.upper() == "GTERI":
+                record = _gteri_parse_line(raw_line)
+                if record is not None:
+                    ingestor.insert(model, head.report, record, spec=spec)
+                    if aggregated_spec is not None:
+                        ingestor.insert(model, head.report, record, spec=aggregated_spec)
+                    return True
             _LOGGER.warning("Línea %s: error al parsear la trama (%s)", line_number, exc)
             return False
 
     ingestor.insert(model, head.report, record, spec=spec)
+    if aggregated_spec is not None:
+        ingestor.insert(model, head.report, record, spec=aggregated_spec)
     return True
 
 
 def _relaxed_gtinf_parse(line: str, spec: Spec) -> Optional[dict[str, object]]:
     tokens = _split_fields(line)
-    if len(tokens) < len(spec.fields):
-        return None
     record: dict[str, object] = {}
-    for field, token in zip(spec.fields, tokens):
-        value: Optional[str] = token if token != "" else None
+    token_iter = iter(tokens)
+    for field in spec.fields:
+        raw = next(token_iter, None)
+        value: Optional[str] = raw if raw not in (None, "") else None
         record[field.name] = value
     record.setdefault("raw_line", line)
     return record

--- a/spec/gv310lau/gteri.yml
+++ b/spec/gv310lau/gteri.yml
@@ -315,11 +315,28 @@ schema:
                     nullable: true
                     when: { mask: append_mask, bit: 13 }
 
-                  relay_state:
-                    type: int
-                    enum: [0,1]
-                    nullable: true
-                    when: { mask: append_mask, bit: 14 }
+                relay_state:
+                  type: int
+                  enum: [0,1]
+                  nullable: true
+                  when: { mask: append_mask, bit: 14 }
+
+        # ---- RAT/Banda (habilitado por eri_mask bit 13/15) ----
+        - name: rat
+          type: int
+          min: 0
+          max: 255
+          optional: true
+          enabled_if_any:
+            - { mask_field: eri_mask, bit: 13 }
+            - { mask_field: eri_mask, bit: 15 }
+
+        - name: band
+          type: string
+          max_length: 8
+          optional: true
+          enabled_if_any:
+            - { field_present: rat }
 
     - name: tail
       fields:

--- a/spec/gv310lau/gtinf.yml
+++ b/spec/gv310lau/gtinf.yml
@@ -23,7 +23,7 @@ schema:
         - { name: csq, type: int, min: 0, max: 255 }
         - { name: ber, type: int, min: 0, max: 99 }
         - { name: ext_power_supply, type: int, enum: [0,1] }
-        - { name: ext_power_voltage_mv, type: int, min: 0, max: 32000 }
+        - { name: ext_power_voltage_mv, type: int, min: 0, max: 32000, optional: true }
         - { name: network_type, type: int, enum: [0,1,2,3] }            # 0=unreg,1=EGPRS,2=WCDMA,3=LTE
         - { name: backup_batt_volt_v, type: float, min: 0.00, max: 5.00, precision: 2 }
         - { name: charging, type: int, enum: [0,1] }

--- a/spec/gv350ceu/gtinf.yml
+++ b/spec/gv350ceu/gtinf.yml
@@ -23,7 +23,7 @@ schema:
         - { name: csq, type: int, min: 0, max: 255 }
         - { name: ber, type: int, min: 0, max: 99 }
         - { name: ext_power_supply, type: int, enum: [0,1] }
-        - { name: ext_power_voltage_mv, type: int, min: 0, max: 32000 }
+        - { name: ext_power_voltage_mv, type: int, min: 0, max: 32000, optional: true }
         - { name: network_type, type: int, min: 0, max: 9 }
         - { name: backup_batt_volt_v, type: float, min: 0.00, max: 5.00, precision: 2 }
         - { name: charging, type: int, enum: [0,1] }

--- a/spec/gv58lau/gteri.yml
+++ b/spec/gv58lau/gteri.yml
@@ -239,10 +239,27 @@ schema:
               max: 100
               present_if: { mask_field: ble_append_mask, bit: 13 }
 
-            - name: ble_relay_state
-              type: int
-              enum: [0,1]
-              present_if: { mask_field: ble_append_mask, bit: 14 }
+        - name: ble_relay_state
+          type: int
+          enum: [0,1]
+          present_if: { mask_field: ble_append_mask, bit: 14 }
+
+        # --- RAT/Banda (habilitado por eri_mask bit 13/15) ---
+        - name: rat
+          type: int
+          min: 0
+          max: 255
+          optional: true
+          enabled_if_any:
+            - { mask_field: eri_mask, bit: 13 }
+            - { mask_field: eri_mask, bit: 15 }
+
+        - name: band
+          type: string
+          max_length: 8
+          optional: true
+          enabled_if_any:
+            - { field_present: rat }
 
     # -----------------------------
     # COLA (FIJA)

--- a/spec/gv58lau/gtinf.yml
+++ b/spec/gv58lau/gtinf.yml
@@ -23,7 +23,7 @@ schema:
         - { name: csq, type: int, min: 0, max: 255 }
         - { name: ber, type: int, min: 0, max: 99 }
         - { name: ext_power_supply, type: int, enum: [0,1] }
-        - { name: ext_power_voltage_mv, type: int, min: 0, max: 32000 }
+        - { name: ext_power_voltage_mv, type: int, min: 0, max: 32000, optional: true }
         - { name: network_type, type: int, min: 0, max: 9 }
         - { name: backup_batt_volt_v, type: float, min: 0.00, max: 5.00, precision: 2 }
         - { name: charging, type: int, enum: [0,1] }


### PR DESCRIPTION
## Summary
- add compatibility wrapper queclink/gteri.py for legacy imports of parse_gteri
- enhance parser, GTERI message handling, CLI, and SQLite ingestor to normalise headers, enrich records, and fall back to the specialised parser when needed
- extend GTERI/GTINF specs to cover RAT/Band fields and optional external power voltage expectations

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68ee5b82dbf48333838c2a4f64f689a7