### PR TITLE
Ensure GV310LAU GTERI spec skips 1-wire entries when count is zero

### DIFF
--- a/docs/gv310lau/gteri.md
+++ b/docs/gv310lau/gteri.md
@@ -111,7 +111,7 @@ Controla los **campos posicionales** después de `<Cell ID>`.
 ### 4.2 ERI Mask (4 bytes, hex)
 Controla los **bloques ERI**:
 - **Bit 0** → *Digital Fuel Sensor Data*.
-- **Bit 1** → *1‑wire Data* (incluye ID/Type/Data). Si Type=1 (temperatura), los datos están en **complemento a dos**; convertir a decimal y multiplicar × 0.0625 °C.
+- **Bit 1** → *1‑wire Data* (incluye ID/Type/Data). Si Type=1 (temperatura), los datos están en **complemento a dos**; convertir a decimal y multiplicar × 0.0625 °C. Si el bit está deshabilitado, el bloque completo (número de dispositivos y lista) no aparece en la trama. Cuando `Device Number` es `0`, tampoco se listan ID/Type/Data. Algunos firmwares omiten `Type` y/o `Data` cuando no hay información adicional; el parser acepta esos campos vacíos/ausentes.
 - **Bit 2** → *CAN Data*.
 - **Bit 10** → *Fuel Sensor Data* (si *Sensor Type* es 2 ó 6, puede incluir *Fuel Temperature*).
 

--- a/docs/gv350ceu/gteri.md
+++ b/docs/gv350ceu/gteri.md
@@ -105,7 +105,22 @@ Los campos solo aparecen si el bit correspondiente está activo. El orden siempr
 | `device_status` | hex | 3 bytes (24 bits) o extendido (40 bits). |
 | `uart_device_type` | int | Tipo de periférico por UART (0,1,7...). |
 
-### 3.4 Accesorios BLE (bit 8 de `eri_mask`)
+### 3.4 1-Wire (bit 1 de `eri_mask`)
+
+Cuando el bit 1 de `eri_mask` está habilitado, el equipo reporta la cantidad de dispositivos 1-Wire conectados y, para cada uno, la información disponible. Si el bit está en `0`, el bloque completo no aparece en la trama.
+
+1. `one_wire_device_number` indica cuántos dispositivos se describen. Si es `0`, no se listan campos adicionales.
+2. Cada elemento de `one_wire_devices` incluye los siguientes campos en el orden indicado:
+
+   | Campo | Tipo | Notas |
+   |---|---|---|
+   | `one_wire_device_id` | hex | ID del dispositivo (8 bytes en ASCII HEX). |
+   | `one_wire_device_type?` | int | Tipo de accesorio (1 = sensor de temperatura). Puede omitirse si el firmware no lo provee. |
+   | `one_wire_device_data?` | hex | Datos crudos asociados. Solo se publica cuando el bit 1 está activo en el *mask* y el equipo tiene información adicional. |
+
+Los campos marcados con `?` son opcionales en la trama y el parser los tolera tanto vacíos como ausentes.
+
+### 3.5 Accesorios BLE (bit 8 de `eri_mask`)
 
 Cuando el bit 8 está activo:
 
@@ -125,7 +140,7 @@ Cuando el bit 8 está activo:
 
 Todos los valores se procesan en el orden descrito; los no presentes se omiten.
 
-### 3.5 RAT / Band (bit 13 de `eri_mask`)
+### 3.6 RAT / Band (bit 13 de `eri_mask`)
 
 Si el bit 13 está activo se agregan dos campos al final del cuerpo:
 

--- a/queclink/parser.py
+++ b/queclink/parser.py
@@ -344,7 +344,10 @@ def _parse_field(field: FieldSpec, stream: _TokenStream, context: _ParseContext)
         return _SKIP
 
     if field.type == "group_repeated":
-        return _parse_group(field, stream, context)
+        count = _repeat_count(field, context)
+        if (count is None or count <= 0) and field.optional:
+            return _SKIP
+        return _parse_group(field, stream, context, count=count)
 
     if stream.remaining() <= 0:
         if field.optional:
@@ -367,9 +370,15 @@ def _parse_field(field: FieldSpec, stream: _TokenStream, context: _ParseContext)
     return value
 
 
-def _parse_group(field: FieldSpec, stream: _TokenStream, context: _ParseContext):
-    repeat_field = field.repeat
-    count = _to_int(context.get(repeat_field)) if repeat_field else 0
+def _parse_group(
+    field: FieldSpec,
+    stream: _TokenStream,
+    context: _ParseContext,
+    *,
+    count: Optional[int] = None,
+):
+    if count is None:
+        count = _repeat_count(field, context)
     if count is None or count < 0:
         count = 0
     items: List[dict] = []
@@ -383,6 +392,13 @@ def _parse_group(field: FieldSpec, stream: _TokenStream, context: _ParseContext)
         items.append(item)
     context.set(field.name, items, str(len(items)) if items else None)
     return items
+
+
+def _repeat_count(field: FieldSpec, context: _ParseContext) -> Optional[int]:
+    repeat_field = field.repeat
+    if not repeat_field:
+        return None
+    return _to_int(context.get(repeat_field))
 
 
 def _should_parse(field: FieldSpec, context: _ParseContext) -> bool:

--- a/spec/gv310lau/gteri.yml
+++ b/spec/gv310lau/gteri.yml
@@ -97,19 +97,23 @@ schema:
           when: { mask: eri_mask, bit: 0 }
 
         # Bit 1: 1-Wire Data
-        - name: one_wire_block
-          type: object
-          when: { mask: eri_mask, bit: 1 }
-          properties:
-            device_number: { type: int, min: 0, max: 19 }
-            devices:
-              type: array
-              items:
-                type: object
-                properties:
-                  id: { type: hex, length: 16 }
-                  type: { type: int, enum: [1], note: "1 => sensor de temperatura (DS18B20)" }
-                  data_raw: { type: hex, max_length: 4, note: "two's complement 16-bit; tempC = decimal * 0.0625" }
+        - name: one_wire_device_number
+          type: int
+          min: 0
+          max: 19
+          optional: true
+          present_if: { mask_field: eri_mask, bit: 1 }
+
+        - name: one_wire_devices
+          type: group_repeated
+          repeat: one_wire_device_number
+          optional: true
+          enabled_if_any:
+            - { mask_field: eri_mask, bit: 1 }
+          fields:
+            - { name: one_wire_device_id,   type: hex,   length_variant: [16] }
+            - { name: one_wire_device_type, type: int,   enum: [1], optional: true, note: "1 => sensor de temperatura (DS18B20)" }
+            - { name: one_wire_device_data, type: hex,   max_length: 40, optional: true, note: "Two's complement 16-bit" }
 
         # Bit 2: CAN Data (ASCII)
         - name: can_data
@@ -348,7 +352,10 @@ masks:
   eri_mask:
     bits:
       0:  { block: digital_fuel_sensor_data }
-      1:  { block: one_wire_block }
+      1:
+        fields:
+          - one_wire_device_number
+          - one_wire_devices
       2:  { block: can_data }
       3:  { note: "Enable Fuel Sensor Data: Percentage", block: fuel_sensor_block }
       4:  { note: "Enable Fuel Sensor Data: Volume", block: fuel_sensor_block }

--- a/spec/gv350ceu/gteri.yml
+++ b/spec/gv350ceu/gteri.yml
@@ -133,21 +133,23 @@ schema:
             - { name: dfs_raw_hex, type: hex, max_length: 64, optional: true }
 
         # ---- 1-Wire Data (iButton / Temp) ----
-         - name: one_wire_device_number
+        - name: one_wire_device_number
           type: int
           min: 0
           max: 19
           optional: true
-          present_if: { mask_field: "eri_mask", bit: 1 }   # se muestra solo si el ERI Mask lo habilita
+          present_if: { mask_field: eri_mask, bit: 1 }   # se muestra solo si el ERI Mask lo habilita
 
         - name: one_wire_devices
-         type: group_repeated
-         repeat: one_wire_device_number
-         optional: true
-         fields:
-          - { name: one_wire_device_id,   type: hex,   length_variant: [16] }
-          - { name: one_wire_device_type, type: int,   min: 1, max: 99 }   # 1 = temp sensor (DS18B20)
-          - { name: one_wire_device_data, type: hex,   max_length: 40 }    # crudo; para tipo 1 es complemento a dos
+          type: group_repeated
+          repeat: one_wire_device_number
+          optional: true
+          enabled_if_any:
+            - { mask_field: eri_mask, bit: 1 }
+          fields:
+            - { name: one_wire_device_id,   type: hex,   length_variant: [16] }
+            - { name: one_wire_device_type, type: int,   min: 1, max: 99, optional: true }   # 1 = temp sensor (DS18B20)
+            - { name: one_wire_device_data, type: hex,   max_length: 40, optional: true }    # crudo; para tipo 1 es complemento a dos
 
 
         # ---- CAN Data (FMS/J1939/OBD-II vía adaptador externo) ----

--- a/tests/test_parser_group_repeated.py
+++ b/tests/test_parser_group_repeated.py
@@ -1,0 +1,29 @@
+"""Tests for repeated group parsing edge cases."""
+
+from queclink.parser import FieldSpec, Spec, parse_line
+
+
+def test_optional_group_skipped_when_repeat_count_is_zero():
+    spec = Spec(
+        model="DUMMY",
+        message="GTFAKE",
+        table_name="fake",
+        delimiter=",",
+        terminator="$",
+        fields=(
+            FieldSpec(name="count", type="int"),
+            FieldSpec(
+                name="devices",
+                type="group_repeated",
+                optional=True,
+                repeat="count",
+                fields=(FieldSpec(name="device_id", type="int"),),
+            ),
+            FieldSpec(name="after", type="int"),
+        ),
+    )
+
+    parsed = parse_line("0,42$", message="GTFAKE", model="DUMMY", spec=spec)
+
+    assert parsed == {"count": 0, "after": 42}
+    assert "devices" not in parsed

--- a/tests/test_spec_one_wire_zero.py
+++ b/tests/test_spec_one_wire_zero.py
@@ -1,0 +1,34 @@
+import pytest
+
+from queclink.parser import FieldSpec, load_spec
+
+
+def _field_map(spec) -> dict[str, FieldSpec]:
+    return {field.name: field for field in spec.fields}
+
+
+@pytest.mark.parametrize("model", ["GV310LAU", "GV350CEU"])
+def test_one_wire_group_configured_as_optional_repeated(model):
+    spec = load_spec(model, "GTERI")
+    fields = _field_map(spec)
+
+    assert "one_wire_device_number" in fields, "count field missing for model"
+    assert "one_wire_devices" in fields, "group field missing for model"
+
+    count_field = fields["one_wire_device_number"]
+    group_field = fields["one_wire_devices"]
+
+    assert count_field.optional, "count should be optional when mask disabled"
+    assert group_field.optional, "group should be optional to tolerate zero count"
+    assert group_field.type == "group_repeated"
+    assert group_field.repeat == "one_wire_device_number"
+
+    nested_names = {nested.name: nested for nested in group_field.fields}
+    assert "one_wire_device_id" in nested_names
+    assert nested_names["one_wire_device_id"].type == "hex"
+
+    assert "one_wire_device_type" in nested_names
+    assert nested_names["one_wire_device_type"].optional
+
+    assert "one_wire_device_data" in nested_names
+    assert nested_names["one_wire_device_data"].optional


### PR DESCRIPTION
## Summary
- align the GV310LAU GTERI spec 1-wire block with GV350CEU so a zero device count omits the repeated entries
- update the ERI mask metadata to point to the new 1-wire fields instead of the legacy block name
- add a regression test that asserts both GV310LAU and GV350CEU specs configure 1-wire as an optional repeated group

## Testing
- pytest tests/test_spec_one_wire_zero.py tests/test_parser_group_repeated.py

------
https://chatgpt.com/codex/tasks/task_e_68ee8c2c7cf48333b5a095a5e1801be8