### PR TITLE
Fix GV310LAU PDOP parsing placeholders

### DIFF
--- a/queclink/messages/gteri.py
+++ b/queclink/messages/gteri.py
@@ -351,6 +351,12 @@ def _parse_model_specific_default(fields: List[str], start_idx: int) -> Dict[str
         return mask_value is not None and (mask_value & bit) != 0
 
     cursor = 0
+
+    def skip_empty_values() -> None:
+        nonlocal cursor
+        while cursor < len(remaining) and (remaining[cursor] or "") == "":
+            cursor += 1
+
     if cursor < len(remaining):
         raw_sat = remaining[cursor]
         if mask_has(0x01):
@@ -361,7 +367,7 @@ def _parse_model_specific_default(fields: List[str], start_idx: int) -> Dict[str
             cursor += 1
 
     dop_keys = ["hdop", "vdop", "pdop"]
-    dop_values: List[Optional[float]] = []
+    dop_values: List[Tuple[int, Optional[float]]] = []
     dop_pattern = r"\d{1,2}(?:\.\d{1,2})?"
     for idx in range(3):
         if cursor >= len(remaining):
@@ -370,34 +376,39 @@ def _parse_model_specific_default(fields: List[str], start_idx: int) -> Dict[str
         expected = mask_has(0x02 << idx)
         if (value or "") == "":
             if expected:
-                dop_values.append(None)
+                dop_values.append((idx, None))
+                cursor += 1
+                continue
+            if any(mask_has(0x02 << future_idx) for future_idx in range(idx + 1, len(dop_keys))):
                 cursor += 1
                 continue
             break
         if re.fullmatch(dop_pattern, value or ""):
-            dop_values.append(_safe_float(value))
+            dop_values.append((idx, _safe_float(value)))
             cursor += 1
             continue
         if expected:
-            dop_values.append(None)
+            dop_values.append((idx, None))
             cursor += 1
             continue
         break
 
-    for idx, value in enumerate(dop_values):
-        if idx < len(dop_keys):
-            out[dop_keys[idx]] = value
-    else:
-        if cursor < len(remaining) and re.fullmatch(r"\d", remaining[cursor] or ""):
-            out["gnss_trigger_type"] = _safe_int(remaining[cursor])
-            cursor += 1
-        if cursor < len(remaining) and re.fullmatch(r"\d", remaining[cursor] or ""):
-            out["gnss_jamming_state"] = _safe_int(remaining[cursor])
-            cursor += 1
+    for idx, value in dop_values:
+        out[dop_keys[idx]] = value
+
+    skip_empty_values()
+    if cursor < len(remaining) and re.fullmatch(r"\d", remaining[cursor] or ""):
+        out["gnss_trigger_type"] = _safe_int(remaining[cursor])
+        cursor += 1
+        skip_empty_values()
+    if cursor < len(remaining) and re.fullmatch(r"\d", remaining[cursor] or ""):
+        out["gnss_jamming_state"] = _safe_int(remaining[cursor])
+        cursor += 1
 
     mileage_set = False
     hour_set = False
 
+    skip_empty_values()
     if cursor < len(remaining) and _is_hour_meter(remaining[cursor]):
         out["hour_meter"] = remaining[cursor]
         cursor += 1
@@ -414,11 +425,6 @@ def _parse_model_specific_default(fields: List[str], start_idx: int) -> Dict[str
         out["mileage_km"] = _safe_float(remaining[cursor])
         cursor += 1
         mileage_set = True
-
-    def skip_empty_values() -> None:
-        nonlocal cursor
-        while cursor < len(remaining) and (remaining[cursor] or "") == "":
-            cursor += 1
 
     analog_pattern = r"-?\d+(?:\.\d+)?|F\d{1,3}"
 

--- a/tests/gv310lau/test_gteri_parser.py
+++ b/tests/gv310lau/test_gteri_parser.py
@@ -86,6 +86,12 @@ RAW_ANALOG_PLACEHOLDERS = (
     "08351B00043C,1,26,65,20231030085704,20231030085704,0017$"
 )
 
+RAW_PDOP_ONLY = (
+    "+RESP:GTERI,6E0C03,868589060796441,GV310LAU,00000000,14095,54,1,1,83.4,61,1120.9,"
+    "-69.777507,-23.288856,20251013124747,0730,0002,00C9,08000620,09,12,,,0.88,,123.45,0000123:45:00,"
+    "111,222,333,90,220100,0,20251013124750,0001$"
+)
+
 RAW_UART_DUP_ZERO = (
     "+RESP:GTERI,6E1203,864696060004173,GV310LAU,00000100,,10,1,1,0.0,0,115.8,"
     "117.129356,31.839248,20230808061540,0460,0001,DF5C,05FE6667,03,15,,4.0,"
@@ -225,6 +231,17 @@ def test_placeholders_no_bloquean_campos_posteriores():
     assert d.get("device_status") == "220100"
     assert d.get("uart_device_type") == 0
     assert d.get("uart_device_type_label") == "unknown"
+
+
+def test_pdop_only_mask_consumes_placeholders():
+    d = parse_gteri(RAW_PDOP_ONLY)
+
+    assert d.get("sats_in_use") == 12
+    assert d.get("pdop") == pytest.approx(0.88)
+    assert d.get("hour_meter") == "0000123:45:00"
+    assert d.get("mileage_km") == pytest.approx(123.45)
+    assert d.get("analog_in_1") == 111
+    assert d.get("device_status") == "220100"
 
 
 def test_uart_device_type_dup_zero():


### PR DESCRIPTION
## Summary
- adjust the GTERI parser for GV310LAU to skip empty DOP placeholders so PDOP values no longer shift the remaining fields
- normalize cursor advancement and empty skipping so mileage, hour meter, and analog inputs stay aligned when only PDOP is sent
- add a regression test covering the PDOP-only mask scenario for GV310LAU

## Testing
- pytest tests/gv310lau/test_gteri_parser.py

------
https://chatgpt.com/codex/tasks/task_e_68eea1ddf9288333b8e4d28d0e2406d0