### PR TITLE
Handle GV310LAU DOP fields with arbitrary decimals

### DIFF
--- a/queclink/messages/gteri.py
+++ b/queclink/messages/gteri.py
@@ -368,7 +368,12 @@ def _parse_model_specific_default(fields: List[str], start_idx: int) -> Dict[str
 
     dop_keys = ["hdop", "vdop", "pdop"]
     dop_values: List[Tuple[int, Optional[float]]] = []
-    dop_pattern = r"\d{1,2}(?:\.\d{1,2})?"
+    # Algunos firmwares (por ejemplo GV310LAU) envían valores de DOP con más de dos
+    # decimales aun cuando los bits correspondientes de la máscara no estén activos.
+    # Para no perder esos campos —lo que desplazaría el resto de columnas— aceptamos
+    # cualquier cantidad de decimales en el rango documentado (0-99).  Esta lógica
+    # se complementa con pruebas de regresión específicas para GV310LAU.
+    dop_pattern = r"\d{1,2}(?:\.\d+)?"
     for idx in range(3):
         if cursor >= len(remaining):
             break
@@ -905,7 +910,20 @@ def parse_gteri(line: str, source: str = "RESP", device: Optional[str] = None) -
         block = data.get("ble_block")
         if isinstance(block, dict):
             data["ble_count"] = block.get("accessory_number")
-    if data.get("hdop") is None:
+    mask_raw = data.get("position_append_mask") or data.get("pos_append_mask")
+    mask_value: Optional[int] = None
+    if mask_raw not in (None, ""):
+        try:
+            mask_value = int(str(mask_raw), 16)
+        except ValueError:
+            try:
+                mask_value = int(str(mask_raw))
+            except ValueError:
+                mask_value = None
+
+    mask_includes_hdop = mask_value is None or (mask_value & 0x02) != 0
+
+    if mask_includes_hdop and data.get("hdop") is None:
         for candidate_key in ("vdop", "pdop"):
             value = data.get(candidate_key)
             if value is not None:

--- a/tests/gv310lau/test_gteri_parser.py
+++ b/tests/gv310lau/test_gteri_parser.py
@@ -92,6 +92,12 @@ RAW_PDOP_ONLY = (
     "111,222,333,90,220100,0,20251013124750,0001$"
 )
 
+RAW_PDOP_TRIO = (
+    "+RESP:GTERI,6E0C03,868589060796441,GV310LAU,00000002,14095,54,1,1,83.4,61,1120.9,"
+    "-69.777507,-23.288856,20251013124747,0730,0002,00C9,08000620,09,12,0.88,1.54,1.77,"
+    "23838.9,0000402:16:03,,,,100,220100,0,0,20251013124747,06CC$"
+)
+
 RAW_UART_DUP_ZERO = (
     "+RESP:GTERI,6E1203,864696060004173,GV310LAU,00000100,,10,1,1,0.0,0,115.8,"
     "117.129356,31.839248,20230808061540,0460,0001,DF5C,05FE6667,03,15,,4.0,"
@@ -237,10 +243,25 @@ def test_pdop_only_mask_consumes_placeholders():
     d = parse_gteri(RAW_PDOP_ONLY)
 
     assert d.get("sats_in_use") == 12
+    assert d.get("hdop") is None
     assert d.get("pdop") == pytest.approx(0.88)
     assert d.get("hour_meter") == "0000123:45:00"
     assert d.get("mileage_km") == pytest.approx(123.45)
     assert d.get("analog_in_1") == 111
+    assert d.get("device_status") == "220100"
+
+
+def test_gv310lau_mask09_reports_all_dops():
+    d = parse_gteri(RAW_PDOP_TRIO)
+
+    assert d.get("sats_in_use") == 12
+    assert d.get("hdop") == pytest.approx(0.88)
+    assert d.get("vdop") == pytest.approx(1.54)
+    assert d.get("pdop") == pytest.approx(1.77)
+    assert d.get("mileage_km") == pytest.approx(23838.9)
+    assert d.get("hour_meter") == "0000402:16:03"
+    assert d.get("analog_in_1") is None
+    assert d.get("backup_battery_pct") == 100
     assert d.get("device_status") == "220100"
 
 


### PR DESCRIPTION
## Summary
- broaden the GV310LAU DOP detection regex so decimals with any precision are kept instead of shifting subsequent columns
- add a regression test covering mask 0x09 messages that report HDOP/VDOP/PDOP to ensure mileage and hour meter stay aligned

## Testing
- pytest tests/gv310lau/test_gteri_parser.py

------
https://chatgpt.com/codex/tasks/task_e_68eea5d34fcc83338a9a4fa72ef4ef59