### PR TITLE
Fix GV58LAU GTERI GNSS trigger parsing

### DIFF
--- a/docs/gv58lau/gteri.md
+++ b/docs/gv58lau/gteri.md
@@ -90,7 +90,7 @@ El valor viene después de `cell_id`.
 | `hdop` | float | 0.00–99.99 (opcional). |
 | `vdop` | float | 0.00–99.99 (opcional). |
 | `pdop` | float | 0.00–99.99 (opcional). |
-| `gnss_trigger_type` | int | Tipo de trigger GNSS (firmware dependiente). |
+| `gnss_trigger_type` | int | Tipo de trigger GNSS (firmware dependiente, solo presente cuando se reportan valores DOP). |
 
 ---
 

--- a/spec/gv58lau/gteri.yml
+++ b/spec/gv58lau/gteri.yml
@@ -68,7 +68,16 @@ schema:
           max: 99.99
           precision: 2
           present_if: { mask_field: pos_append_mask, bit: 3 }
-        - { name: gnss_trigger_type, type: int, min: 0, max: 9, optional: true, description: "Trigger GNSS reportado tras los DOP." }
+        - name: gnss_trigger_type
+          type: int
+          min: 0
+          max: 9
+          optional: true
+          description: "Trigger GNSS reportado tras los DOP."
+          present_if_any:
+            - { field_present: hdop }
+            - { field_present: vdop }
+            - { field_present: pdop }
 
         # --- Vehicle counters / status ---
         - { name: mileage_km, type: float, min: 0.0, max: 4294967.0, precision: 1 }


### PR DESCRIPTION
## Summary
- gate the optional `gnss_trigger_type` field in the GV58LAU GTERI spec behind the presence of DOP readings to keep subsequent fields aligned
- update the GV58LAU GTERI documentation to mention when `gnss_trigger_type` is expected

## Testing
- python queclink_tramas.py --in /tmp/gteri_samples.txt --out /tmp/out.db --message GTERI
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68efab74b86c8333a1e881819b944aa5