### PR TITLE
Corrige mapeo BLE en ingestión SQLite de GTERI

### DIFF
--- a/queclink/parser.py
+++ b/queclink/parser.py
@@ -372,6 +372,14 @@ def parse_line(
         value = _parse_field(field, stream, context, remaining_fields=remaining)
         if value is not _SKIP:
             result[field.name] = value
+
+    normalized_report = message
+    if normalized_report:
+        normalized_report = normalized_report.upper()
+    if normalized_report and "report" not in result:
+        result["report"] = normalized_report
+    if normalized_report and "message" not in result:
+        result["message"] = normalized_report
     return result
 
 
@@ -509,21 +517,23 @@ def _is_bit_set(value: object, bit: int) -> bool:
     if bit < 0:
         return False
 
-    numeric = _to_int(value)
-    if numeric is not None and (numeric & (1 << bit)):
-        return True
+    numeric: Optional[int] = None
 
     if isinstance(value, str):
         text = value.strip()
-        if text:
-            try:
-                numeric_hex = int(text, 16)
-            except ValueError:
-                numeric_hex = None
-            else:
-                return bool(numeric_hex & (1 << bit))
+        if not text:
+            return False
+        try:
+            numeric = int(text, 16)
+        except ValueError:
+            numeric = _to_int(value)
+    else:
+        numeric = _to_int(value)
 
-    return False
+    if numeric is None:
+        return False
+
+    return bool(numeric & (1 << bit))
 
 
 def _to_int(value: object) -> Optional[int]:

--- a/spec/gv310lau/gteri.yml
+++ b/spec/gv310lau/gteri.yml
@@ -21,8 +21,7 @@ schema:
   sections:
     - name: head
       fields:
-        - { name: header, const_any: ["+RESP:GT", "+BUFF:GT"], type: string }
-        - { name: message, const: "ERI", type: string }
+        - { name: header, const_any: ["+RESP:GTERI", "+BUFF:GTERI"], type: string }
         - { name: full_protocol_version, type: hex, length: 6, example: "6E1203" }
         - { name: imei, type: string, length: 15, pattern: "^[0-9]{15}$", example: "864696060004173" }
         - { name: device_name, type: string, max_length: 20, pattern: "^[0-9A-Za-z_-]{1,20}$", example: "GV310LAU" }

--- a/spec/gv350ceu/gteri.yml
+++ b/spec/gv350ceu/gteri.yml
@@ -17,8 +17,7 @@ schema:
     # =========================
     - name: head
       fields:
-        - { name: header, const_any: ["+RESP:GT", "+BUFF:GT"], type: string }
-        - { name: message, const: "ERI", type: string }
+        - { name: header, const_any: ["+RESP:GTERI", "+BUFF:GTERI"], type: string }
         - { name: full_protocol_version, type: hex, length_variant: [6, 7] }
         - { name: imei, type: string, length: 15, pattern: "^[0-9]{15}$" }
         - { name: device_name, type: string, max_length: 20 }

--- a/spec/gv58lau/gteri.yml
+++ b/spec/gv58lau/gteri.yml
@@ -14,8 +14,7 @@ schema:
   sections:
     - name: head
       fields:
-        - { name: header, const_any: ["+RESP:GT", "+BUFF:GT"], type: string }
-        - { name: message, const: "ERI", type: string }
+        - { name: header, const_any: ["+RESP:GTERI", "+BUFF:GTERI"], type: string }
         - { name: full_protocol_version, type: hex, length: 10 }
         - { name: imei, type: string, length: 15, pattern: "^[0-9]{15}$" }
         - { name: device_name, type: string, min_length: 4, max_length: 20 }

--- a/src/ingestors/sqlite_records.py
+++ b/src/ingestors/sqlite_records.py
@@ -9,6 +9,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Iterable, Optional
 
+from queclink.parser import load_spec as load_parser_spec
 from queclink.parser import parse_line
 
 _LOGGER = logging.getLogger(__name__)
@@ -35,8 +36,8 @@ def resolve_spec(report: str, model: str) -> dict:
     spec_path = _repository_root() / "spec" / model_norm / f"{report_norm}.yml"
     if not spec_path.exists():
         raise FileNotFoundError(spec_path)
-    fields = _extract_spec_fields(spec_path)
-    return {"path": spec_path, "fields": fields}
+    spec_obj = load_parser_spec(model.strip().upper(), report.strip().upper())
+    return {"path": spec_path, "fields": spec_obj.fields, "spec": spec_obj}
 
 
 def _strip_comment(line: str) -> str:
@@ -187,6 +188,17 @@ def spec_to_sql_columns(spec: dict) -> list[tuple[str, str]]:
         "list": "TEXT",
         "array": "TEXT",
     }
+    spec_obj = spec.get("spec")
+    if spec_obj is not None:
+        columns: list[tuple[str, str]] = []
+        for field in getattr(spec_obj, "fields", []):
+            if not getattr(field, "name", None):
+                continue
+            type_name = str(getattr(field, "type", "") or "").strip().lower()
+            sql_type = type_map.get(type_name, "TEXT")
+            columns.append((field.name, sql_type))
+        return columns
+
     columns: list[tuple[str, str]] = []
     for field in spec.get("fields", []):
         name = field.get("name")


### PR DESCRIPTION
## Summary
- Ajusta los encabezados de las especificaciones GTERI para GV310/350/58, haciendo coincidir el prefijo completo del mensaje.
- Normaliza el parser genérico para poblar los campos report/message y manejar máscaras hexadecimales al evaluar bits.
- Reutiliza el Spec del parser en la ingesta SQLite y serializa los grupos repetidos (como los accesorios BLE) como JSON.

## Testing
- pytest tests/gv58lau/test_gteri_parser.py -q

------
https://chatgpt.com/codex/tasks/task_e_68efbbd182b08333b1dbfc5200a0f5dd