### PR TITLE
Add GV58LAU GTFRI homologation

### DIFF
--- a/spec/gv58lau/gtfri.yml
+++ b/spec/gv58lau/gtfri.yml
@@ -21,7 +21,7 @@ schema:
     - name: head
       fields:
         - { name: header, const_any: ["+RESP:GTFRI", "+BUFF:GTFRI"], type: string }
-        - { name: full_protocol_version, type: hex, length: 6, example: "6E1203" }
+        - { name: full_protocol_version, type: hex, length_variant: [6, 10], example: "6E1203" }
         - { name: imei, type: string, length: 15, pattern: "^[0-9]{15}$", example: "866314060873492" }
         - { name: device_name, type: string, max_length: 20, pattern: "^[0-9A-Za-z_-]{1,20}$", example: "GV58LAU" }
 
@@ -50,8 +50,30 @@ schema:
         # --- Position Append Mask (1 byte) y campos dependientes ---
         - { name: position_append_mask, type: hex, length: 2, example: "03" }
         - { name: sats_in_use, type: int, min: 0, max: 72, when: { mask: position_append_mask, bit: 0 } }
-        - { name: hdop, type: float, min: 0.00, max: 99.99, when: { mask: position_append_mask, bit: 1 } }
-        - { name: vdop, type: float, min: 0.00, max: 99.99, when: { mask: position_append_mask, bit: 2 } }
+        -
+          name: hdop
+          type: float
+          min: 0.00
+          max: 99.99
+          when:
+            any_of:
+              - { mask: position_append_mask, bit: 1 }
+              -
+                all_of:
+                  - { mask: position_append_mask, bit: 3 }
+                  - { feature: posmask_bit3_mode, equals: pdop }
+        -
+          name: vdop
+          type: float
+          min: 0.00
+          max: 99.99
+          when:
+            any_of:
+              - { mask: position_append_mask, bit: 2 }
+              -
+                all_of:
+                  - { mask: position_append_mask, bit: 3 }
+                  - { feature: posmask_bit3_mode, equals: pdop }
         - { name: pdop_or_acc_factor, type: float, min: 0.00, max: 99.99, when: { mask: position_append_mask, bit: 3 }, note: "PDOP o GNSS accuracy factor según config.posmask_bit3_mode" }
 
         # --- Contadores y entradas analógicas ---
@@ -70,7 +92,7 @@ schema:
       fields:
         - { name: send_time, type: datetime, format: "YYYYMMDDHHMMSS", tz: "UTC" }
         - { name: count_number, type: hex, length: 4 }
-        - { name: tail, const: "$", type: string }
+        - { name: tail, const: "$", type: string, optional: true, default_if_absent: "$" }
 
 masks:
   position_append_mask:

--- a/src/ingestors/sqlite_records.py
+++ b/src/ingestors/sqlite_records.py
@@ -40,6 +40,24 @@ def resolve_spec(report: str, model: str) -> dict:
     return {"path": spec_path, "fields": spec_obj.fields, "spec": spec_obj}
 
 
+def _table_name(report: str, model: str, spec: dict) -> str:
+    spec_obj = spec.get("spec")
+    if spec_obj is not None:
+        table_name = getattr(spec_obj, "table_name", None)
+        if table_name:
+            return str(table_name)
+
+    report_lower = (report or "").strip().lower()
+    model_lower = (model or "").strip().lower()
+    if model_lower and report_lower:
+        return f"{report_lower}_{model_lower}"
+    if report_lower:
+        return f"{report_lower}_records"
+    if model_lower:
+        return f"{model_lower}_records"
+    return "records"
+
+
 def _strip_comment(line: str) -> str:
     in_single = False
     in_double = False
@@ -211,29 +229,46 @@ def spec_to_sql_columns(spec: dict) -> list[tuple[str, str]]:
 
 
 def ensure_table(conn, report: str, model: str, spec: dict) -> None:
-    report_lower = report.strip().lower()
-    table = f"{report_lower}_records"
+    table = _table_name(report, model, spec)
     columns = spec_to_sql_columns(spec)
-    column_defs = ["id INTEGER PRIMARY KEY AUTOINCREMENT"]
+    column_defs: list[str] = []
     seen: set[str] = set()
     for name, sql_type in columns:
         if name in seen:
             continue
         seen.add(name)
-        column_defs.append(f"\"{name}\" {sql_type}")
-    unique_candidates = ("imei", "send_time", "count_hex")
-    if all(field in seen for field in unique_candidates):
-        column_defs.append("UNIQUE(imei, send_time, count_hex)")
-    conn.execute(
-        f"CREATE TABLE IF NOT EXISTS {table} ({', '.join(column_defs)})"
+        column_defs.append(f'"{name}" {sql_type}')
+
+    if not column_defs:
+        return
+
+    cursor = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+        (table,),
     )
-    if {"imei", "send_time"}.issubset(seen):
+    table_exists = cursor.fetchone() is not None
+    if not table_exists:
         conn.execute(
-            f"CREATE INDEX IF NOT EXISTS idx_{table}_imei_send_time ON {table} (imei, send_time)"
+            f'CREATE TABLE IF NOT EXISTS "{table}" ({", ".join(column_defs)})'
+        )
+    else:
+        existing_info = conn.execute(f'PRAGMA table_info("{table}")').fetchall()
+        existing_columns = {row[1] for row in existing_info}
+        for name, sql_type in columns:
+            if name not in existing_columns:
+                conn.execute(
+                    f'ALTER TABLE "{table}" ADD COLUMN "{name}" {sql_type}'
+                )
+
+    if {"imei", "send_time"}.issubset(seen):
+        index_name = f"idx_{table}_imei_send_time"
+        conn.execute(
+            f'CREATE INDEX IF NOT EXISTS {index_name} ON "{table}" (imei, send_time)'
         )
     if {"model", "send_time"}.issubset(seen):
+        index_name = f"idx_{table}_model_send_time"
         conn.execute(
-            f"CREATE INDEX IF NOT EXISTS idx_{table}_model_send_time ON {table} (model, send_time)"
+            f'CREATE INDEX IF NOT EXISTS {index_name} ON "{table}" (model, send_time)'
         )
     conn.commit()
 
@@ -273,6 +308,14 @@ def normalize_for_sql(spec: dict, parsed: dict) -> dict:
     report = parsed.get("report") or parsed.get("message")
     row: dict[str, Optional[object]] = {}
     column_types = spec_to_sql_columns(spec)
+    field_specs = {}
+    spec_obj = spec.get("spec")
+    if spec_obj is not None:
+        field_specs = {
+            getattr(field, "name", ""): field
+            for field in getattr(spec_obj, "fields", [])
+            if getattr(field, "name", None)
+        }
     for column, sql_type in column_types:
         raw_value = parsed.get(column)
         if raw_value in ("", None):
@@ -287,18 +330,29 @@ def normalize_for_sql(spec: dict, parsed: dict) -> dict:
             else:
                 value = _as_text(raw_value)
         if value is None and column not in parsed:
+            field_spec = field_specs.get(column)
+            if field_spec and (
+                getattr(field_spec, "optional", False)
+                or getattr(field_spec, "present_if", None)
+                or getattr(field_spec, "present_if_any", None)
+                or getattr(field_spec, "enabled_if_any", None)
+            ):
+                row[column] = value
+                continue
             _LOGGER.warning("[WARN] missing field %s for report %s", column, report)
         row[column] = value
     return row
 
 
-def insert_record(conn, report: str, row: dict) -> None:
-    report_lower = report.strip().lower()
-    table = f"{report_lower}_records"
+def insert_record(conn, report: str, model: str, spec: dict, row: dict) -> None:
+    table = _table_name(report, model, spec)
     columns = list(row.keys())
     escaped_columns = [f'"{col}"' for col in columns]
     placeholders = ", ".join(f":{col}" for col in columns)
-    sql = f"INSERT OR IGNORE INTO {table} ({', '.join(escaped_columns)}) VALUES ({placeholders})"
+    sql = (
+        f'INSERT OR IGNORE INTO "{table}" '
+        f"({', '.join(escaped_columns)}) VALUES ({placeholders})"
+    )
     conn.execute(sql, row)
     conn.commit()
 
@@ -339,7 +393,7 @@ def ingest_lines(
             continue
         ensure_table(conn, report, model, spec)
         row = normalize_for_sql(spec, parsed)
-        insert_record(conn, report, row)
+        insert_record(conn, report, model, spec, row)
         inserted += 1
 
     return inserted

--- a/tests/gv58lau/test_gtfri_parser.py
+++ b/tests/gv58lau/test_gtfri_parser.py
@@ -1,0 +1,45 @@
+from queclink.parser import parse_line
+
+
+RESP_SAMPLE = (
+    "+RESP:GTFRI,8020040900,866314061768998,GV58LAU,12714,50,1,1,0.0,235,2923.1,"\
+    "-68.867600,-22.201688,20251016151536,0730,0001,0899,00542913,01,12,6537.2,"\
+    "0000219:06:11,,,,100,220100,,,,20251016151537,591D$"
+)
+
+
+BUFF_SAMPLE_PDOP = (
+    "+BUFF:GTFRI,8020040703,866314061771471,GV58LAU,28204,10,1,1,29.9,25,142.2,"\
+    "-71.586724,-33.590164,20251015190846,,,,,08,0.69,1.11,1.30,659946.1,"\
+    "0001265:29:11,,,,100,220100,,,,20251015190847,868C$"
+)
+
+
+def test_parse_gtfri_resp_basic_fields():
+    data = parse_line(RESP_SAMPLE)
+
+    assert data.get("header") == "+RESP:GTFRI"
+    assert data.get("message") == "GTFRI"
+    assert data.get("imei") == "866314061768998"
+    assert data.get("device_name") == "GV58LAU"
+
+    assert data.get("position_append_mask") == "01"
+    assert data.get("sats_in_use") == 12
+    assert data.get("mileage_km") == 6537.2
+
+    assert data.get("count_number") == "591D"
+    assert data.get("tail") == "$"
+
+
+def test_parse_gtfri_buff_handles_pdop_bundle():
+    data = parse_line(BUFF_SAMPLE_PDOP)
+
+    assert data.get("header") == "+BUFF:GTFRI"
+    assert data.get("position_append_mask") == "08"
+
+    assert data.get("hdop") == 0.69
+    assert data.get("vdop") == 1.11
+    assert data.get("pdop_or_acc_factor") == 1.3
+
+    assert data.get("count_number") == "868C"
+    assert data.get("tail") == "$"

--- a/tests/test_sqlite_records_gtfri.py
+++ b/tests/test_sqlite_records_gtfri.py
@@ -1,0 +1,46 @@
+from src.ingestors.sqlite_records import (
+    ensure_db,
+    ingest_lines,
+    resolve_spec,
+    spec_to_sql_columns,
+)
+
+
+GTFRI_LINES = [
+    "+RESP:GTFRI,8020040900,866314061768998,GV58LAU,12714,50,1,1,0.0,235,2923.1,"\
+    "-68.867600,-22.201688,20251016151536,0730,0001,0899,00542913,01,12,6537.2,"\
+    "0000219:06:11,,,,100,220100,,,,20251016151537,591D$",
+    "+BUFF:GTFRI,8020040703,866314061771471,GV58LAU,28204,10,1,1,29.9,25,142.2,"\
+    "-71.586724,-33.590164,20251015190846,,,,,08,0.69,1.11,1.30,659946.1,"\
+    "0001265:29:11,,,,100,220100,,,,20251015190847,868C$",
+]
+
+
+def test_ingest_lines_creates_gtfri_table_with_spec_columns():
+    conn = ensure_db(":memory:")
+
+    inserted = ingest_lines(conn, GTFRI_LINES, message="GTFRI")
+    assert inserted == len(GTFRI_LINES)
+
+    spec = resolve_spec("GTFRI", "GV58LAU")
+    table_name = spec["spec"].table_name
+
+    cursor = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+        (table_name,),
+    )
+    assert cursor.fetchone() is not None
+
+    info = conn.execute(f'PRAGMA table_info("{table_name}")').fetchall()
+    columns = [row[1] for row in info]
+    expected_columns = [name for name, _ in spec_to_sql_columns(spec)]
+    assert columns == expected_columns
+
+    rows = conn.execute(
+        f'SELECT imei, hdop, vdop, pdop_or_acc_factor, tail FROM "{table_name}" '
+        "ORDER BY send_time"
+    ).fetchall()
+    assert rows == [
+        ("866314061771471", 0.69, 1.11, 1.3, "$"),
+        ("866314061768998", None, None, None, "$"),
+    ]


### PR DESCRIPTION
## Summary
- extend the GV58LAU GTFRI spec to accept bundled DOP values and default the tail terminator
- update the generic SQLite ingestor to honor spec table names and only create the documented columns
- cover GTFRI parsing and ingestion with tests using real GV58LAU samples

## Testing
- pytest tests/gv58lau/test_gtfri_parser.py tests/test_sqlite_records_gtfri.py -q


------
https://chatgpt.com/codex/tasks/task_e_68f10f55d0508333896f61c3e40193cb