### PR TITLE
Handle BOM-prefixed GTFRI headers

### DIFF
--- a/queclink/parser.py
+++ b/queclink/parser.py
@@ -624,13 +624,29 @@ def _convert_value(raw: str, field_type: str):
     return raw
 
 
+def _strip_bom(text: str) -> str:
+    """Remove Unicode byte order marks (BOM) from the beginning of a string."""
+
+    if not text:
+        return text
+
+    # Python already strips common whitespace with ``str.strip`` but BOM characters
+    # are not considered whitespace. Some Windows editors (e.g. Notepad) may inject a
+    # UTF-8 BOM (``\ufeff``) at the beginning of exported log files which makes the
+    # first token fail the ``const_any`` validation (e.g. ``+RESP:GTFRI``). By
+    # normalising those characters we make the parser resilient to those files while
+    # keeping the remaining payload untouched.
+    return text.lstrip("\ufeff\ufffe")
+
+
 def _tokenize(line: str, delimiter: str = ",", terminator: str = "$") -> List[str]:
-    payload = line.strip()
+    payload = _strip_bom(line).strip()
     if terminator and payload.endswith(terminator):
         payload = payload[: -len(terminator)]
     if not payload:
         return []
-    return [part.strip() for part in payload.split(delimiter)]
+    parts = [part.strip() for part in payload.split(delimiter)]
+    return [_strip_bom(part) for part in parts]
 
 
 def _split(line: str) -> List[str]:

--- a/tests/gv58lau/test_gtfri_parser.py
+++ b/tests/gv58lau/test_gtfri_parser.py
@@ -43,3 +43,11 @@ def test_parse_gtfri_buff_handles_pdop_bundle():
 
     assert data.get("count_number") == "868C"
     assert data.get("tail") == "$"
+
+
+def test_parse_gtfri_resp_ignores_bom_on_header():
+    bom_line = "\ufeff" + RESP_SAMPLE
+
+    data = parse_line(bom_line)
+
+    assert data.get("header") == "+RESP:GTFRI"


### PR DESCRIPTION
## Summary
- strip UTF-8 BOM characters before tokenising Queclink log lines so header validation tolerates BOM-prefixed frames
- add a regression test confirming the GV58LAU GTFRI parser accepts frames that start with a BOM

## Testing
- pytest tests/gv58lau/test_gtfri_parser.py

------
https://chatgpt.com/codex/tasks/task_e_68f114f4d46c8333a663c021afc73c39