### PR TITLE
Add GV310LAU GTFRI spec coverage and ingestion tests

### DIFF
--- a/spec/gv310lau/gtfri.yml
+++ b/spec/gv310lau/gtfri.yml
@@ -50,28 +50,46 @@ schema:
 
         # --- Append Mask de posición (estilo GV58LAU) ---
         - { name: position_append_mask, type: hex, length: 2, description: "00-FF (Bit0=Sats, Bit1=H-Acc, Bit2=V-Acc, Bit3=3D-Acc)" }
-        - { name: satellites_in_use, type: int, min: 0, max: 72, nullable: true, when: { mask: position_append_mask, bit: 0 }, allow_empty: true }
-        - { name: horizontal_gnss_accuracy, type: float, min: 0.00, max: 99.99, nullable: true, when: { mask: position_append_mask, bit: 1 }, allow_empty: true }
-        - { name: vertical_gnss_accuracy, type: float, min: 0.00, max: 99.99, nullable: true, when: { mask: position_append_mask, bit: 2 }, allow_empty: true }
-        - { name: gnss_3d_accuracy, type: float, min: 0.00, max: 99.99, nullable: true, when: { mask: position_append_mask, bit: 3 }, allow_empty: true }
+        - { name: satellites_in_use, type: int, min: 0, max: 72, optional: true, when: { mask: position_append_mask, bit: 0 } }
+        -
+          name: horizontal_gnss_accuracy
+          type: float
+          min: 0.00
+          max: 99.99
+          optional: true
+          when:
+            any_of:
+              - { mask: position_append_mask, bit: 1 }
+              - { mask: position_append_mask, bit: 3 }
+        -
+          name: vertical_gnss_accuracy
+          type: float
+          min: 0.00
+          max: 99.99
+          optional: true
+          when:
+            any_of:
+              - { mask: position_append_mask, bit: 2 }
+              - { mask: position_append_mask, bit: 3 }
+        - { name: gnss_3d_accuracy, type: float, min: 0.00, max: 99.99, optional: true, when: { mask: position_append_mask, bit: 3 } }
 
         # --- Acumulados / IO ---
         - { name: mileage_km, type: float, min: 0.0, max: 4294967.0 }
         - { name: hour_meter, type: string, pattern: "^[0-9]{7}:[0-5][0-9]:[0-5][0-9]$", example: "0000000:00:00" }
-        - { name: analog_in_1, type: string, max_length: 5, nullable: true, description: "0-16000(mV)|F(0-100)" }
-        - { name: analog_in_2, type: string, max_length: 5, nullable: true, description: "0-16000(mV)|F(0-100)" }
-        - { name: analog_in_3, type: string, max_length: 5, nullable: true, description: "0-16000(mV)|F(0-100)" }
-        - { name: backup_battery_percentage, type: int, min: 0, max: 100, nullable: true }
+        - { name: analog_in_1, type: string, max_length: 5, optional: true, description: "0-16000(mV)|F(0-100)" }
+        - { name: analog_in_2, type: string, max_length: 5, optional: true, description: "0-16000(mV)|F(0-100)" }
+        - { name: analog_in_3, type: string, max_length: 5, optional: true, description: "0-16000(mV)|F(0-100)" }
+        - { name: backup_battery_percentage, type: int, min: 0, max: 100, optional: true }
         - { name: device_status, type: hex, length_variant: [6,10] }
-        - { name: reserved1, type: string, length: 0, nullable: true }
-        - { name: reserved2, type: string, length: 0, nullable: true }
-        - { name: reserved3, type: string, length: 0, nullable: true }
+        - { name: reserved1, type: string, optional: true }
+        - { name: reserved2, type: string, optional: true }
+        - { name: reserved3, type: string, optional: true }
 
     - name: tail
       fields:
         - { name: send_time, type: datetime, format: "YYYYMMDDHHMMSS" }
         - { name: count_number, type: hex, length: 4, description: "0000-FFFF (no es CRC)" }
-        - { name: tail, const: "$", type: string }
+        - { name: tail, const: "$", type: string, optional: true, default_if_absent: "$" }
 
 # --------- Derivaciones útiles ---------
 derivations:

--- a/tests/gv310lau/test_gtfri_parser.py
+++ b/tests/gv310lau/test_gtfri_parser.py
@@ -1,0 +1,51 @@
+from queclink.parser import parse_line
+
+
+RESP_SAMPLE = (
+    "+RESP:GTFRI,6E0C03,868589060693259,GV310LAU,25194,10,1,1,0.0,16,440.5,"\
+    "-70.309823,-23.760673,20251016180342,0730,0002,00CE,0985D171,00,183603.6,"\
+    "0000748:27:41,,,,100,210100,,,,20251016180343,28C2$"
+)
+
+
+MASKED_SAMPLE = (
+    "+RESP:GTFRI,6E0C03,868589060367029,GV310LAU,28177,10,1,1,86.1,84,793.1,"\
+    "-70.088989,-23.450741,20251016180340,0730,0001,0837,002BED03,09,11,0.85,"\
+    "1.15,1.43,89436.1,0001852:29:57,,,,100,220100,,,,20251016180342,A9B5$"
+)
+
+
+BUFF_SAMPLE = MASKED_SAMPLE.replace("+RESP", "+BUFF", 1)
+
+
+def test_parse_gtfri_gv310lau_basic_optional_fields():
+    data = parse_line(RESP_SAMPLE)
+
+    assert data.get("header") == "+RESP:GTFRI"
+    assert data.get("message") == "GTFRI"
+    assert data.get("unique_id") == "868589060693259"
+    assert data.get("device_name") == "GV310LAU"
+
+    assert data.get("position_append_mask") == "00"
+    assert data.get("satellites_in_use") is None
+    assert data.get("backup_battery_percentage") == 100
+    assert data.get("tail") == "$"
+
+
+def test_parse_gtfri_gv310lau_with_append_mask_data():
+    data = parse_line(MASKED_SAMPLE)
+
+    assert data.get("position_append_mask") == "09"
+    assert data.get("satellites_in_use") == 11
+    assert data.get("horizontal_gnss_accuracy") == 0.85
+    assert data.get("vertical_gnss_accuracy") == 1.15
+    assert data.get("gnss_3d_accuracy") == 1.43
+    assert data.get("count_number") == "A9B5"
+
+
+def test_parse_gtfri_gv310lau_buff_header_supported():
+    data = parse_line(BUFF_SAMPLE)
+
+    assert data.get("header") == "+BUFF:GTFRI"
+    assert data.get("message") == "GTFRI"
+    assert data.get("unique_id") == "868589060367029"

--- a/tests/test_sqlite_records_gtfri.py
+++ b/tests/test_sqlite_records_gtfri.py
@@ -6,7 +6,7 @@ from src.ingestors.sqlite_records import (
 )
 
 
-GTFRI_LINES = [
+GTFRI_GV58LAU_LINES = [
     "+RESP:GTFRI,8020040900,866314061768998,GV58LAU,12714,50,1,1,0.0,235,2923.1,"\
     "-68.867600,-22.201688,20251016151536,0730,0001,0899,00542913,01,12,6537.2,"\
     "0000219:06:11,,,,100,220100,,,,20251016151537,591D$",
@@ -16,11 +16,21 @@ GTFRI_LINES = [
 ]
 
 
-def test_ingest_lines_creates_gtfri_table_with_spec_columns():
+GTFRI_GV310LAU_LINES = [
+    "+RESP:GTFRI,6E0C03,868589060693259,GV310LAU,25194,10,1,1,0.0,16,440.5,"\
+    "-70.309823,-23.760673,20251016180342,0730,0002,00CE,0985D171,00,183603.6,"\
+    "0000748:27:41,,,,100,210100,,,,20251016180343,28C2$",
+    "+BUFF:GTFRI,6E0C03,868589060367029,GV310LAU,28177,10,1,1,87.9,83,791.2,"\
+    "-70.089688,-23.450809,20251016180337,0730,0001,0837,002BED03,09,11,0.88,"\
+    "1.29,1.56,89436.1,0001852:29:54,,,,100,220100,,,,20251016180339,A9B4$",
+]
+
+
+def test_ingest_lines_creates_gtfri_gv58lau_table_with_spec_columns():
     conn = ensure_db(":memory:")
 
-    inserted = ingest_lines(conn, GTFRI_LINES, message="GTFRI")
-    assert inserted == len(GTFRI_LINES)
+    inserted = ingest_lines(conn, GTFRI_GV58LAU_LINES, message="GTFRI")
+    assert inserted == len(GTFRI_GV58LAU_LINES)
 
     spec = resolve_spec("GTFRI", "GV58LAU")
     table_name = spec["spec"].table_name
@@ -43,4 +53,35 @@ def test_ingest_lines_creates_gtfri_table_with_spec_columns():
     assert rows == [
         ("866314061771471", 0.69, 1.11, 1.3, "$"),
         ("866314061768998", None, None, None, "$"),
+    ]
+
+
+def test_ingest_lines_creates_gtfri_gv310lau_table_with_spec_columns():
+    conn = ensure_db(":memory:")
+
+    inserted = ingest_lines(conn, GTFRI_GV310LAU_LINES, message="GTFRI")
+    assert inserted == len(GTFRI_GV310LAU_LINES)
+
+    spec = resolve_spec("GTFRI", "GV310LAU")
+    table_name = spec["spec"].table_name
+
+    cursor = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+        (table_name,),
+    )
+    assert cursor.fetchone() is not None
+
+    info = conn.execute(f'PRAGMA table_info("{table_name}")').fetchall()
+    columns = [row[1] for row in info]
+    expected_columns = [name for name, _ in spec_to_sql_columns(spec)]
+    assert columns == expected_columns
+
+    rows = conn.execute(
+        f'SELECT unique_id, satellites_in_use, horizontal_gnss_accuracy, '
+        f'vertical_gnss_accuracy, gnss_3d_accuracy, backup_battery_percentage, '
+        f'tail FROM "{table_name}" ORDER BY count_number'
+    ).fetchall()
+    assert rows == [
+        ("868589060693259", None, None, None, None, 100, "$"),
+        ("868589060367029", 11, 0.88, 1.29, 1.56, 100, "$"),
     ]


### PR DESCRIPTION
## Summary
- update the GV310LAU GTFRI spec so optional append mask and analog fields are handled without misalignment
- add GV310LAU GTFRI parser tests using RESP and BUFF samples
- extend the SQLite ingestion checks to ensure the gtfri_gv310lau table matches the spec columns

## Testing
- pytest tests/gv310lau/test_gtfri_parser.py tests/test_sqlite_records_gtfri.py

------
https://chatgpt.com/codex/tasks/task_e_68f1400e73988333890c51461ae6eb28