### PR TITLE
Add GV350CEU GTFRI coverage and SQLite ingestion helpers

### DIFF
--- a/queclink/ingestor_sqlite.py
+++ b/queclink/ingestor_sqlite.py
@@ -6,9 +6,9 @@ import json
 import sqlite3
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, Sequence
+from typing import Iterable, Optional, Sequence
 
-from .parser import FieldSpec, Spec, load_spec
+from .parser import FieldSpec, Spec, load_spec, parse_line, parse_gteri, parse_gtinf
 
 
 def _type_to_sql(field: FieldSpec) -> str:
@@ -26,6 +26,144 @@ def _normalize_value(value):
     if isinstance(value, bool):
         return int(value)
     return value
+
+
+def init_db(path: str | Path) -> sqlite3.Connection:
+    """Return a SQLite connection ensuring parent directories exist."""
+
+    db_path = Path(path)
+    if db_path != Path(":memory:"):
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+    return sqlite3.connect(str(db_path))
+
+
+def _normalize_report_name(message: str) -> str:
+    normalized = (message or "").strip().upper()
+    if normalized and not normalized.startswith("GT"):
+        normalized = f"GT{normalized}"
+    return normalized
+
+
+def _table_name(model: str, message: str) -> str:
+    model_norm = (model or "").strip().lower()
+    message_norm = (message or "").strip().lower()
+    if model_norm and message_norm:
+        return f"{model_norm}_{message_norm}"
+    if model_norm:
+        return f"{model_norm}_records"
+    if message_norm:
+        return f"{message_norm}_records"
+    return "records"
+
+
+def _ensure_table(conn: sqlite3.Connection, spec: Spec, table: str) -> Sequence[FieldSpec]:
+    fields = spec.fields
+    existing = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+        (table,),
+    ).fetchone()
+
+    if existing is None:
+        columns_sql = ", ".join(
+            f'"{field.name}" {_type_to_sql(field)}' for field in fields
+        )
+        conn.execute(
+            f'CREATE TABLE IF NOT EXISTS "{table}" ({columns_sql})'
+        )
+    else:
+        info = conn.execute(f'PRAGMA table_info("{table}")').fetchall()
+        existing_columns = {row[1] for row in info}
+        for field in fields:
+            if field.name not in existing_columns:
+                conn.execute(
+                    f'ALTER TABLE "{table}" ADD COLUMN "{field.name}" '
+                    f"{_type_to_sql(field)}"
+                )
+    conn.commit()
+    return fields
+
+
+def _iter_lines(path: Path) -> Iterable[str]:
+    with path.open("r", encoding="utf-8") as handle:
+        for raw_line in handle:
+            line = raw_line.strip()
+            if line:
+                yield line
+
+
+def bulk_ingest_from_file(
+    conn: sqlite3.Connection,
+    model: str,
+    message: str,
+    input_path: str | Path,
+) -> int:
+    """Parse Queclink lines from a file and insert them into SQLite."""
+
+    path = Path(input_path)
+    if not path.exists():
+        raise FileNotFoundError(path)
+
+    model_clean = (model or "").strip()
+    if not model_clean:
+        raise ValueError("Model name is required")
+
+    normalized_message = _normalize_report_name(message)
+    spec = load_spec(model_clean.upper(), normalized_message)
+    model_lower = model_clean.lower()
+    if normalized_message == "GTERI":
+        table = f"{model_lower}_{normalized_message.lower()}"
+    elif normalized_message == "GTINF":
+        table = f"{normalized_message.lower()}_{model_lower}"
+    else:
+        table = _table_name(model_clean, message)
+    fields = _ensure_table(conn, spec, table)
+
+    columns = [field.name for field in fields]
+    placeholders = ", ".join(["?"] * len(columns))
+    column_names = ", ".join(f'"{col}"' for col in columns)
+
+    inserted = 0
+    for line in _iter_lines(path):
+        try:
+            record = parse_line(
+                line,
+                model=model_clean.upper(),
+                message=normalized_message,
+                spec=spec,
+            )
+        except Exception:
+            if normalized_message == "GTERI":
+                record = parse_gteri(line, device=model_clean)
+            elif normalized_message == "GTINF":
+                record = parse_gtinf(line, device=model_clean)
+            else:
+                continue
+            if not record:
+                continue
+
+        report_value = record.get("report") or record.get("message")
+        report = str(report_value or "").strip().upper()
+        if normalized_message == "GTINF" and report == "INF":
+            report = normalized_message
+        if normalized_message and report and report != normalized_message:
+            continue
+
+        values = [
+            _normalize_value(
+                record.get(column)
+                if column in record
+                else record.get(f"{column}_raw")
+            )
+            for column in columns
+        ]
+        conn.execute(
+            f'INSERT INTO "{table}" ({column_names}) VALUES ({placeholders})',
+            values,
+        )
+        inserted += 1
+
+    conn.commit()
+    return inserted
 
 
 @dataclass
@@ -77,5 +215,5 @@ class SQLiteIngestor:
         return {row[1] for row in info.fetchall()}
 
 
-__all__ = ["SQLiteIngestor"]
+__all__ = ["SQLiteIngestor", "init_db", "bulk_ingest_from_file"]
 

--- a/tests/gv350ceu/test_gtfri_parser.py
+++ b/tests/gv350ceu/test_gtfri_parser.py
@@ -1,0 +1,51 @@
+"""Tests for GV350CEU GTFRI parser support."""
+
+from queclink.parser import parse_line
+
+
+RESP_SAMPLE = (
+    "+RESP:GTFRI,740904,862524060867948,GV350CEU,,10,1,1,89.5,169,672.9,"\
+    "-70.292914,-23.949947,20251016184033,0730,0001,0836,002BEE06,01,12,"\
+    "775824.1,0000439:30:29,,,,100,221102,,,,20251016184035,AA3C$"
+)
+
+
+BUFF_SAMPLE = (
+    "+BUFF:GTFRI,740904,862524060867948,GV350CEU,,10,1,1,89.6,168,690.2,"\
+    "-70.291068,-23.958760,20251016184113,0730,0001,0836,002BEE06,01,12,"\
+    "775825.1,0000439:31:11,,,,100,221102,,,,20251016184115,AA41$"
+)
+
+
+def test_parse_gtfri_gv350ceu_resp_core_fields():
+    data = parse_line(RESP_SAMPLE)
+
+    assert data.get("header") == "+RESP:GTFRI"
+    assert data.get("message") == "GTFRI"
+    assert data.get("unique_id") == "862524060867948"
+    assert data.get("device_name") == "GV350CEU"
+
+    assert data.get("position_append_mask") == "01"
+    assert data.get("satellites_in_use") == 12
+    assert data.get("mileage_km") == 775824.1
+
+    assert data.get("analog_in_1") is None
+    assert data.get("analog_in_2") is None
+    assert data.get("analog_in_3") is None
+    assert data.get("backup_battery_percentage") == 100
+
+    assert data.get("count_number") == "AA3C"
+    assert data.get("tail") == "$"
+
+
+def test_parse_gtfri_gv350ceu_buff_tail_fields():
+    data = parse_line(BUFF_SAMPLE)
+
+    assert data.get("header") == "+BUFF:GTFRI"
+    assert data.get("message") == "GTFRI"
+    assert data.get("unique_id") == "862524060867948"
+
+    assert data.get("send_time") == "20251016184115"
+    assert data.get("count_number") == "AA41"
+    assert data.get("tail") == "$"
+

--- a/tests/test_sqlite_records_gtfri.py
+++ b/tests/test_sqlite_records_gtfri.py
@@ -26,6 +26,16 @@ GTFRI_GV310LAU_LINES = [
 ]
 
 
+GTFRI_GV350CEU_LINES = [
+    "+RESP:GTFRI,740904,862524060867948,GV350CEU,,10,1,1,89.5,169,672.9,"\
+    "-70.292914,-23.949947,20251016184033,0730,0001,0836,002BEE06,01,12,"\
+    "775824.1,0000439:30:29,,,,100,221102,,,,20251016184035,AA3C$",
+    "+BUFF:GTFRI,740904,862524060867948,GV350CEU,,10,1,1,89.6,168,690.2,"\
+    "-70.291068,-23.958760,20251016184113,0730,0001,0836,002BEE06,01,12,"\
+    "775825.1,0000439:31:11,,,,100,221102,,,,20251016184115,AA41$",
+]
+
+
 def test_ingest_lines_creates_gtfri_gv58lau_table_with_spec_columns():
     conn = ensure_db(":memory:")
 
@@ -84,4 +94,35 @@ def test_ingest_lines_creates_gtfri_gv310lau_table_with_spec_columns():
     assert rows == [
         ("868589060693259", None, None, None, None, 100, "$"),
         ("868589060367029", 11, 0.88, 1.29, 1.56, 100, "$"),
+    ]
+
+
+def test_ingest_lines_creates_gtfri_gv350ceu_table_with_spec_columns():
+    conn = ensure_db(":memory:")
+
+    inserted = ingest_lines(conn, GTFRI_GV350CEU_LINES, message="GTFRI")
+    assert inserted == len(GTFRI_GV350CEU_LINES)
+
+    spec = resolve_spec("GTFRI", "GV350CEU")
+    table_name = spec["spec"].table_name
+
+    cursor = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+        (table_name,),
+    )
+    assert cursor.fetchone() is not None
+
+    info = conn.execute(f'PRAGMA table_info("{table_name}")').fetchall()
+    columns = [row[1] for row in info]
+    expected_columns = [name for name, _ in spec_to_sql_columns(spec)]
+    assert columns == expected_columns
+
+    rows = conn.execute(
+        f'SELECT unique_id, position_append_mask, satellites_in_use, '
+        f'analog_in_1, backup_battery_percentage, device_status, tail '
+        f'FROM "{table_name}" ORDER BY send_time'
+    ).fetchall()
+    assert rows == [
+        ("862524060867948", "01", 12, None, 100, "221102", "$"),
+        ("862524060867948", "01", 12, None, 100, "221102", "$"),
     ]


### PR DESCRIPTION
## Summary
- add parser and SQLite ingestion tests that exercise GV350CEU GTFRI payloads
- extend sqlite ingestion helpers with init_db/bulk_ingest_from_file and relaxed parsing fallbacks
- ensure ingestion tests can create the expected tables for GTFRI, GTERI and GTINF samples

## Testing
- `pytest tests/test_sqlite_records_gtfri.py tests/gv350ceu/test_gtfri_parser.py tests/test_ingestor_sqlite.py`


------
https://chatgpt.com/codex/tasks/task_e_68f148def0a883339a846d50b0a688c8