### PR TITLE
Add GTJDS homologation tests for GV310LAU

### DIFF
--- a/tests/gv310lau/test_gtjds_parser.py
+++ b/tests/gv310lau/test_gtjds_parser.py
@@ -1,0 +1,82 @@
+"""Parser tests for GV310LAU +RESP/+BUFF:GTJDS messages."""
+
+from queclink.parser import parse_line
+
+
+RESP_SAMPLE = (
+    "+RESP:GTJDS,6E0C03,868589060379784,GV310LAU,1,3,1,85.7,350,1206.3,"
+    "-69.972567,-28.038460,20251016202522,0730,0001,0C82,00550412,00,"
+    "20251016202522,8170$"
+)
+
+
+RESP_WITH_MASK = (
+    "+RESP:GTJDS,6E0C03,868589060255190,GV310LAU,1,3,0,126.8,339,759.7,"
+    "-70.625297,-33.348113,20251016202239,0730,0002,0517,00103625,0F,10,"
+    "0.75,1.10,1.80,20251016202301,837A$"
+)
+
+
+BUFF_SAMPLE = (
+    "+BUFF:GTJDS,6E0201,868589060079137,GV310LAU,2,5,0,0.0,249,117.2,"
+    "-109.358792,-27.140638,20251016201343,,,,,00,20251016201442,8A0F$"
+)
+
+
+def test_parse_gtjds_resp_core_fields():
+    data = parse_line(RESP_SAMPLE)
+
+    assert data.get("header") == "+RESP:GTJDS"
+    assert data.get("message") == "GTJDS"
+    assert data.get("unique_id") == "868589060379784"
+    assert data.get("device_name") == "GV310LAU"
+
+    assert data.get("jamming_state") == 1
+    assert data.get("jamming_net") == 3
+    assert data.get("gnss_accuracy_level") == 1
+
+    assert data.get("mcc") == "0730"
+    assert data.get("mnc") == "0001"
+    assert data.get("lac_hex") == "0C82"
+    assert data.get("cell_id_hex") == "00550412"
+
+    assert data.get("position_append_mask") == "00"
+    assert data.get("satellites_in_use") is None
+    assert data.get("horizontal_gnss_accuracy") is None
+    assert data.get("vertical_gnss_accuracy") is None
+    assert data.get("gnss_3d_accuracy") is None
+
+    assert data.get("tail") == "$"
+
+
+def test_parse_gtjds_resp_append_mask_fields():
+    data = parse_line(RESP_WITH_MASK)
+
+    assert data.get("header") == "+RESP:GTJDS"
+    assert data.get("message") == "GTJDS"
+    assert data.get("unique_id") == "868589060255190"
+
+    assert data.get("position_append_mask") == "0F"
+    assert data.get("satellites_in_use") == 10
+    assert data.get("horizontal_gnss_accuracy") == 0.75
+    assert data.get("vertical_gnss_accuracy") == 1.10
+    assert data.get("gnss_3d_accuracy") == 1.80
+
+    assert data.get("send_time") == "20251016202301"
+    assert data.get("count_number") == "837A"
+
+
+def test_parse_gtjds_buff_handles_missing_cellular_data():
+    data = parse_line(BUFF_SAMPLE)
+
+    assert data.get("header") == "+BUFF:GTJDS"
+    assert data.get("message") == "GTJDS"
+    assert data.get("unique_id") == "868589060079137"
+
+    assert data.get("mcc") == ""
+    assert data.get("mnc") == ""
+    assert data.get("lac_hex") == ""
+    assert data.get("cell_id_hex") == ""
+
+    assert data.get("position_append_mask") == "00"
+    assert data.get("tail") == "$"

--- a/tests/test_sqlite_records_gtjds.py
+++ b/tests/test_sqlite_records_gtjds.py
@@ -1,0 +1,93 @@
+"""SQLite ingestion tests for GV310LAU GTJDS records."""
+
+from src.ingestors.sqlite_records import (
+    ensure_db,
+    ingest_lines,
+    resolve_spec,
+    spec_to_sql_columns,
+)
+
+
+GTJDS_LINES = [
+    "+RESP:GTJDS,6E0C03,868589060379784,GV310LAU,1,3,1,85.7,350,1206.3,"
+    "-69.972567,-28.038460,20251016202522,0730,0001,0C82,00550412,00,"
+    "20251016202522,8170$",
+    "+RESP:GTJDS,6E0C03,868589060255190,GV310LAU,1,3,0,126.8,339,759.7,"
+    "-70.625297,-33.348113,20251016202239,0730,0002,0517,00103625,0F,10,"
+    "0.75,1.10,1.80,20251016202301,837A$",
+    "+BUFF:GTJDS,6E0201,868589060248765,GV310LAU,2,3,0,29.1,64,472.4,"
+    "-72.157288,-38.322191,20251016201851,,,,,00,20251016201851,80DE$",
+]
+
+
+def test_ingest_lines_creates_gtjds_gv310lau_table_with_spec_columns():
+    conn = ensure_db(":memory:")
+
+    inserted = ingest_lines(conn, GTJDS_LINES, message="GTJDS")
+    assert inserted == len(GTJDS_LINES)
+
+    spec = resolve_spec("GTJDS", "GV310LAU")
+    table_name = spec["spec"].table_name
+
+    cursor = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+        (table_name,),
+    )
+    assert cursor.fetchone() is not None
+
+    info = conn.execute(f'PRAGMA table_info("{table_name}")').fetchall()
+    columns = [row[1] for row in info]
+    expected_columns = [name for name, _ in spec_to_sql_columns(spec)]
+    assert columns == expected_columns
+
+    rows = conn.execute(
+        f'SELECT unique_id, jamming_state, jamming_net, position_append_mask, '
+        f'satellites_in_use, horizontal_gnss_accuracy, vertical_gnss_accuracy, '
+        f'gnss_3d_accuracy, mcc, mnc, lac_hex, cell_id_hex '
+        f'FROM "{table_name}" ORDER BY send_time'
+    ).fetchall()
+
+    assert rows == [
+        (
+            "868589060248765",
+            2,
+            3,
+            "00",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ),
+        (
+            "868589060255190",
+            1,
+            3,
+            "0F",
+            10,
+            0.75,
+            1.10,
+            1.80,
+            "0730",
+            "0002",
+            "0517",
+            "00103625",
+        ),
+        (
+            "868589060379784",
+            1,
+            3,
+            "00",
+            None,
+            None,
+            None,
+            None,
+            "0730",
+            "0001",
+            "0C82",
+            "00550412",
+        ),
+    ]


### PR DESCRIPTION
## Summary
- add parser coverage for GV310LAU GTJDS +RESP/+BUFF samples, including append mask fields
- verify SQLite ingestion creates the gtjds_gv310lau table with the YAML spec columns and stores optional GNSS accuracy data

## Testing
- pytest tests/gv310lau/test_gtjds_parser.py tests/test_sqlite_records_gtjds.py

------
https://chatgpt.com/codex/tasks/task_e_68f1583ba8c88333b7748ce9d635fe4b