### PR TITLE
Handle missing folium dependency when generating maps

### DIFF
--- a/viz/mapa_recorridos.py
+++ b/viz/mapa_recorridos.py
@@ -9,9 +9,14 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 
-import folium
-from folium import FeatureGroup, LayerControl, Map
-from folium.plugins import FeatureGroupSubGroup
+try:  # pragma: no cover - dependencia opcional en tiempo de ejecución
+    import folium
+    from folium import FeatureGroup, LayerControl, Map
+    from folium.plugins import FeatureGroupSubGroup
+except ModuleNotFoundError as exc:  # pragma: no cover - entorno sin folium
+    raise ModuleNotFoundError(
+        "folium no está instalado. Ejecuta 'pip install folium pytz python-dateutil'"
+    ) from exc
 
 from src.ingestors.sqlite_records import ensure_db
 


### PR DESCRIPTION
## Summary
- guard the folium imports in `viz/mapa_recorridos.py`
- raise a clear error instructing how to install the visualization dependencies when folium is missing

## Testing
- pytest tests/viz/test_folium_map.py

------
https://chatgpt.com/codex/tasks/task_e_68f244bce410833396714417742e81a4