### PR TITLE
Add WOM operator support to interactive map

### DIFF
--- a/viz/mapa_recorridos.py
+++ b/viz/mapa_recorridos.py
@@ -73,6 +73,7 @@ OPERATOR_COLORS = {
     "Entel": "#1f77b4",
     "Claro": "#ff7f0e",
     "Movistar": "#2ca02c",
+    "WOM": "#9467bd",
     "Desconocido": "#7f7f7f",
 }
 
@@ -149,6 +150,8 @@ def _normalize_operator(mcc: Optional[int], mnc: Optional[int]) -> str:
         return "Movistar"
     if mnc == 3:
         return "Claro"
+    if mnc == 9:
+        return "WOM"
     return "Desconocido"
 
 


### PR DESCRIPTION
## Summary
- add WOM operator color for interactive map visualizations
- extend operator normalization to recognize MNC 0009 as WOM

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f27addd39883338fabfd7c1da7f34a