### PR TITLE
Fix operator detection when MCC/MNC have leading zeros

### DIFF
--- a/tests/viz/test_mapa_recorridos.py
+++ b/tests/viz/test_mapa_recorridos.py
@@ -1,0 +1,20 @@
+import pytest
+
+pytest.importorskip("folium")
+
+from viz.mapa_recorridos import _normalize_operator, _safe_int
+
+
+def test_safe_int_parses_leading_zero_decimal():
+    assert _safe_int("0730") == 730
+    assert _safe_int("0009") == 9
+
+
+def test_safe_int_keeps_base_prefix_support():
+    assert _safe_int("0x10") == 16
+
+
+def test_normalize_operator_known_chile_carriers():
+    assert _normalize_operator(730, 2) == "Movistar"
+    assert _normalize_operator(730, 9) == "WOM"
+    assert _normalize_operator(472, 9) == "Desconocido"

--- a/viz/mapa_recorridos.py
+++ b/viz/mapa_recorridos.py
@@ -132,13 +132,28 @@ def _safe_float(value: object) -> Optional[float]:
 def _safe_int(value: object) -> Optional[int]:
     if value in (None, ""):
         return None
-    try:
-        return int(str(value), 0)
-    except (TypeError, ValueError):
-        try:
-            return int(str(value).lstrip("0") or "0")
-        except ValueError:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        if value != value:  # NaN check sin importar math.isnan
             return None
+        return int(value)
+
+    text = str(value).strip()
+    if not text:
+        return None
+
+    try:
+        return int(text, 10)
+    except ValueError:
+        try:
+            return int(text, 0)
+        except ValueError:
+            cleaned = text.lstrip("0").strip() or "0"
+            try:
+                return int(cleaned, 10)
+            except ValueError:
+                return None
 
 
 def _normalize_operator(mcc: Optional[int], mnc: Optional[int]) -> str:


### PR DESCRIPTION
## Summary
- ensure `_safe_int` parses leading-zero MCC/MNC values as decimal before using automatic base detection
- add regression tests covering operator normalization for Movistar and WOM codes

## Testing
- pytest tests/viz/test_mapa_recorridos.py

------
https://chatgpt.com/codex/tasks/task_e_68f27d289a4c8333b94bdb4994dcf74c