### PR TITLE
Handle missing MCC when normalizing operators

### DIFF
--- a/tests/viz/test_mapa_recorridos.py
+++ b/tests/viz/test_mapa_recorridos.py
@@ -17,4 +17,9 @@ def test_safe_int_keeps_base_prefix_support():
 def test_normalize_operator_known_chile_carriers():
     assert _normalize_operator(730, 2) == "Movistar"
     assert _normalize_operator(730, 9) == "WOM"
+    assert _normalize_operator(None, 9) == "WOM"
     assert _normalize_operator(472, 9) == "Desconocido"
+
+
+def test_normalize_operator_requires_mnc():
+    assert _normalize_operator(730, None) == "Desconocido"

--- a/viz/mapa_recorridos.py
+++ b/viz/mapa_recorridos.py
@@ -157,7 +157,9 @@ def _safe_int(value: object) -> Optional[int]:
 
 
 def _normalize_operator(mcc: Optional[int], mnc: Optional[int]) -> str:
-    if mcc != 730:
+    if mnc is None:
+        return "Desconocido"
+    if mcc is not None and mcc != 730:
         return "Desconocido"
     if mnc == 1:
         return "Entel"
@@ -456,7 +458,9 @@ class OperatorLegend(MacroElement):
     def __init__(self, colors: Dict[str, str]):
         super().__init__()
         entries = []
-        for operator in ("Entel", "Claro", "Movistar"):
+        for operator in sorted(
+            key for key in colors.keys() if key.lower() != "desconocido"
+        ):
             color = colors.get(operator)
             if not color:
                 continue


### PR DESCRIPTION
## Summary
- allow operator normalization to accept Chilean carriers when MCC is missing
- render the operator legend dynamically so WOM is listed when present
- extend unit tests to cover MCC-less and missing MNC scenarios

## Testing
- pytest tests/viz/test_mapa_recorridos.py

------
https://chatgpt.com/codex/tasks/task_e_68f2800b9c4c8333b16dbd05de0f975f