### PR TITLE
feat: enriquecer mapas con base fusionada y filtros completos

### DIFF
--- a/docs/viz/mapa_recorridos_por_imei.md
+++ b/docs/viz/mapa_recorridos_por_imei.md
@@ -2,8 +2,9 @@
 
 Esta guía describe la nueva vista que combina los reportes de ubicación (`GTERI`/`GTFRI`)
 con los reportes informativos (`GTINF`) para enriquecer un mapa interactivo por IMEI.
-El proceso trabaja **solo en memoria** a partir de las bases SQLite generadas por el
-homologador; no modifica ninguna de las bases existentes.
+Para cada modelo se genera una base auxiliar `<reporte>_<modelo>_map.db` que replica los
+registros originales e incorpora las columnas `tecnologia_celular`, `calidad_senal` y
+`nivel_senal_dbm`. Las bases originales del homologador permanecen inalteradas.
 
 ## Requisitos previos
 
@@ -23,8 +24,8 @@ homologador; no modifica ninguna de las bases existentes.
    por `send_time`.
 3. **Enriquecimiento**: cada punto de recorrido adopta la tecnología (`network_type`) y
    la intensidad de señal (`csq`, `ber`) del **último GTINF cuyo `send_time` sea menor o
-   igual** al del punto. Si no existe un GTINF anterior, el punto se marca como
-   "Desconocida".
+   igual** al del punto. El resultado se guarda en la base auxiliar mencionada.
+   Si no existe un GTINF anterior, el punto se marca como "Desconocida".
 4. **Clasificación**: la señal se traduce a dBm y se clasifica como Pésima/Regular/Buena/
    Excelente según los umbrales definidos para 2G/3G/4G.
 
@@ -71,8 +72,10 @@ El HTML generado se almacena como `mapa_<modelo>_<imei>.html` en el directorio i
 
 ## Consideraciones
 
-- La fusión se realiza cada vez que se genera el mapa; no persiste ningún cambio en las
-  bases SQLite.
+- La base `<reporte>_<modelo>_map.db` se regenera automáticamente si cambia la fecha de
+  modificación de `gteri_<modelo>.db`, `gtfri_<modelo>.db` o `gtinf_<modelo>.db`.
+- Las columnas calculadas (`tecnologia_celular`, `calidad_senal`, `nivel_senal_dbm`) se
+  utilizan para los filtros del mapa y se completan con la última medición GTINF previa.
 - Si no se encuentra un GTINF anterior para un punto, este se conserva con tecnología y
   señal "Desconocida".
 - Los umbrales de clasificación pueden ajustarse en `viz/mapa_recorridos.py` si fuese

--- a/tests/viz/test_mapa_recorridos.py
+++ b/tests/viz/test_mapa_recorridos.py
@@ -1,10 +1,14 @@
+import sqlite3
 from datetime import datetime, timedelta
+from pathlib import Path
 
 import pytest
 
 pytest.importorskip("folium")
 
 from viz.mapa_recorridos import (
+    build_points,
+    render_interactive_map,
     InfoRecord,
     LocationPoint,
     _associate_info,
@@ -12,6 +16,7 @@ from viz.mapa_recorridos import (
     _normalize_operator,
     _safe_int,
 )
+from viz.enriched_db import ensure_enriched_database
 
 
 def test_safe_int_parses_leading_zero_decimal():
@@ -59,6 +64,49 @@ def _make_info(offset_seconds: int, *, label: str, csq: float, csq_ber: int | No
     )
 
 
+def _prepare_sample_databases(tmp_path: Path) -> Path:
+    model = "gv350ceu"
+    imei = "123456789012345"
+    base_dir = tmp_path
+
+    gteri_path = base_dir / f"gteri_{model}.db"
+    conn = sqlite3.connect(gteri_path)
+    conn.execute(
+        f'CREATE TABLE "gteri_{model}" ('
+        'imei TEXT, send_time TEXT, lat REAL, lon REAL, mcc TEXT, mnc TEXT)'
+    )
+    conn.executemany(
+        f'INSERT INTO "gteri_{model}" (imei, send_time, lat, lon, mcc, mnc) '
+        'VALUES (?, ?, ?, ?, ?, ?)',
+        [
+            (imei, "202510100000", -33.45, -70.66, "0730", "0002"),
+            (imei, "202510100020", -33.46, -70.65, "0730", "0002"),
+            (imei, "202510100120", -33.47, -70.64, "0730", "0002"),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    gtinf_path = base_dir / f"gtinf_{model}.db"
+    conn = sqlite3.connect(gtinf_path)
+    conn.execute(
+        f'CREATE TABLE "gtinf_{model}" ('
+        'imei TEXT, send_time TEXT, network_type INTEGER, csq REAL, csq_ber INTEGER)'
+    )
+    conn.executemany(
+        f'INSERT INTO "gtinf_{model}" (imei, send_time, network_type, csq, csq_ber) '
+        'VALUES (?, ?, ?, ?, ?)',
+        [
+            (imei, "202510100000", 3, 160, None),
+            (imei, "202510100100", 1, 12, None),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    return base_dir
+
+
 def test_associate_info_uses_latest_previous_record():
     points = [
         _make_point(0),
@@ -104,3 +152,71 @@ def test_filter_points_accepts_all_keyword_for_every_filter():
     assert _filter_points(points, operators=["All"]) == points
     assert _filter_points(points, networks=["ALL"]) == points
     assert _filter_points(points, day="all") == points
+
+
+def test_enriched_database_creates_columns_and_values(tmp_path: Path):
+    base_dir = _prepare_sample_databases(tmp_path)
+
+    enriched_path = ensure_enriched_database(
+        report="gteri", model="gv350ceu", base_dir=base_dir
+    )
+    assert enriched_path.exists()
+
+    conn = sqlite3.connect(enriched_path)
+    try:
+        rows = conn.execute(
+            'SELECT tecnologia_celular, calidad_senal, nivel_senal_dbm '
+            'FROM "gteri_gv350ceu" ORDER BY send_time'
+        ).fetchall()
+    finally:
+        conn.close()
+
+    tecnologias = [row[0] for row in rows]
+    calidades = [row[1] for row in rows]
+    niveles = [row[2] for row in rows]
+
+    assert tecnologias == ["4G", "4G", "2G"]
+    assert calidades == ["Excelente", "Excelente", "Buena"]
+    assert niveles[0] == pytest.approx(20.0)
+    assert niveles[2] == pytest.approx(-89.0)
+
+
+def test_build_points_uses_enriched_database(tmp_path: Path):
+    base_dir = _prepare_sample_databases(tmp_path)
+    # Genera la base enriquecida y asegura reutilización posterior
+    ensure_enriched_database(report="gteri", model="gv350ceu", base_dir=base_dir)
+
+    points = build_points(
+        model="gv350ceu",
+        imei="123456789012345",
+        base_dir=base_dir,
+        reports=["gteri"],
+    )
+
+    assert len(points) == 3
+    assert [p.network_label for p in points] == ["4G", "4G", "2G"]
+    assert [p.signal_quality for p in points] == ["Excelente", "Excelente", "Buena"]
+    assert [p.operator for p in points] == ["Movistar"] * 3
+    assert points[0].lat == pytest.approx(-33.45)
+    assert points[0].lon == pytest.approx(-70.66)
+
+
+def test_render_interactive_map_includes_all_filters(tmp_path: Path):
+    pytest.importorskip("folium")
+    base_dir = _prepare_sample_databases(tmp_path)
+    ensure_enriched_database(report="gteri", model="gv350ceu", base_dir=base_dir)
+
+    points = build_points(
+        model="gv350ceu",
+        imei="123456789012345",
+        base_dir=base_dir,
+        reports=["gteri"],
+    )
+
+    output_html = tmp_path / "mapa.html"
+    render_interactive_map(points, output_html)
+
+    html = output_html.read_text(encoding="utf-8")
+    assert "Todos los días" in html
+    assert "Operador Movistar" in html
+    assert "Tecnología 4G" in html

--- a/viz/enriched_db.py
+++ b/viz/enriched_db.py
@@ -1,0 +1,184 @@
+"""Generación de bases SQLite enriquecidas con información GTINF."""
+from __future__ import annotations
+
+import shutil
+import sqlite3
+from collections import defaultdict
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+from src.ingestors.sqlite_records import ensure_db
+
+from .utils import (
+    CSQ_BER_CANDIDATES,
+    CSQ_CANDIDATES,
+    IMEI_CANDIDATES,
+    NETWORK_TYPE_CANDIDATES,
+    NETWORK_TYPE_MAP,
+    TIME_CANDIDATES,
+    classify_signal,
+    detect_table,
+    first_existing,
+    load_table_schema,
+    parse_datetime,
+    safe_float,
+    safe_int,
+)
+
+
+def _ensure_column(conn: sqlite3.Connection, table: str, column: str, definition: str) -> None:
+    info = conn.execute(f'PRAGMA table_info("{table}")').fetchall()
+    existing = {row[1] for row in info}
+    if column not in existing:
+        conn.execute(f'ALTER TABLE "{table}" ADD COLUMN "{column}" {definition}')
+
+
+def _load_gtinf_lookup(
+    gtinf_path: Path, model: str
+) -> Dict[str, List[Tuple[datetime, str, str, Optional[float]]]]:
+    if not gtinf_path.exists():
+        return {}
+
+    conn = ensure_db(gtinf_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        table = detect_table(conn, "gtinf", model)
+        columns = load_table_schema(conn, table)
+        imei_col = first_existing(IMEI_CANDIDATES, columns)
+        time_col = first_existing(TIME_CANDIDATES, columns)
+        network_col = first_existing(NETWORK_TYPE_CANDIDATES, columns)
+        if not imei_col or not time_col or not network_col:
+            return {}
+
+        csq_col = first_existing(CSQ_CANDIDATES, columns)
+        ber_col = first_existing(CSQ_BER_CANDIDATES, columns)
+
+        query_cols = {imei_col, time_col, network_col}
+        if csq_col:
+            query_cols.add(csq_col)
+        if ber_col:
+            query_cols.add(ber_col)
+        select_clause = ", ".join(f'"{col}"' for col in query_cols)
+        sql = f'SELECT {select_clause} FROM "{table}" ORDER BY "{time_col}"'
+
+        lookup: Dict[str, List[Tuple[datetime, str, str, Optional[float]]]] = defaultdict(list)
+        for row in conn.execute(sql):
+            imei_raw = row[imei_col]
+            imei = str(imei_raw).strip() if imei_raw not in (None, "") else None
+            if not imei:
+                continue
+            send_dt = parse_datetime(row[time_col])
+            if send_dt is None:
+                continue
+            raw_network = safe_int(row[network_col])
+            network_label = NETWORK_TYPE_MAP.get(raw_network, "Desconocida")
+            csq = safe_float(row[csq_col]) if csq_col else None
+            csq_ber = safe_int(row[ber_col]) if ber_col else None
+            quality, dbm = classify_signal(network_label, csq, csq_ber)
+            lookup[imei].append((send_dt, network_label, quality, dbm))
+        return {key: sorted(values, key=lambda item: item[0]) for key, values in lookup.items()}
+    finally:
+        conn.close()
+
+
+def _resolve_output_path(base_dir: Path, report: str, model: str) -> Path:
+    name = f"{report}_{model}_map.db"
+    return base_dir / name
+
+
+def ensure_enriched_database(*, report: str, model: str, base_dir: Path | str) -> Path:
+    """Genera (si es necesario) una copia enriquecida de la base de recorridos."""
+
+    base_path = Path(base_dir)
+    report_clean = report.strip().lower()
+    model_clean = model.strip().lower()
+    source_path = base_path / f"{report_clean}_{model_clean}.db"
+    if not source_path.exists():
+        raise FileNotFoundError(source_path)
+
+    output_path = _resolve_output_path(base_path, report_clean, model_clean)
+    gtinf_path = base_path / f"gtinf_{model_clean}.db"
+
+    needs_regen = True
+    if output_path.exists():
+        src_mtime = source_path.stat().st_mtime
+        out_mtime = output_path.stat().st_mtime
+        gtinf_mtime = gtinf_path.stat().st_mtime if gtinf_path.exists() else None
+        if out_mtime >= src_mtime and (gtinf_mtime is None or out_mtime >= gtinf_mtime):
+            needs_regen = False
+
+    if needs_regen:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        if output_path.exists():
+            output_path.unlink()
+        shutil.copy2(source_path, output_path)
+
+        conn = ensure_db(output_path)
+        conn.row_factory = sqlite3.Row
+        try:
+            table = detect_table(conn, report_clean, model_clean)
+            _ensure_column(conn, table, "tecnologia_celular", "TEXT")
+            _ensure_column(conn, table, "calidad_senal", "TEXT")
+            _ensure_column(conn, table, "nivel_senal_dbm", "REAL")
+
+            columns = load_table_schema(conn, table)
+            imei_col = first_existing(IMEI_CANDIDATES, columns)
+            time_col = first_existing(TIME_CANDIDATES, columns)
+            if not imei_col or not time_col:
+                return output_path
+            # Aseguramos valores por defecto para evitar residuos de ejecuciones previas.
+            conn.execute(
+                f'UPDATE "{table}" SET "tecnologia_celular" = "Desconocida", '
+                '"calidad_senal" = "Desconocida", "nivel_senal_dbm" = NULL'
+            )
+
+            gtinf_lookup = _load_gtinf_lookup(gtinf_path, model_clean)
+            if not gtinf_lookup:
+                conn.commit()
+                return output_path
+
+            select_sql = (
+                f'SELECT ROWID as __rowid__, "{imei_col}" as imei_value, '
+                f'"{time_col}" as send_value FROM "{table}" ORDER BY "{time_col}"'
+            )
+            updates: List[Tuple[str, str, Optional[float], int]] = []
+            positions: Dict[str, int] = defaultdict(int)
+
+            for row in conn.execute(select_sql):
+                imei_val = row["imei_value"]
+                imei = str(imei_val).strip() if imei_val not in (None, "") else None
+                if not imei:
+                    continue
+                send_dt = parse_datetime(row["send_value"])
+                if send_dt is None:
+                    continue
+                infos = gtinf_lookup.get(imei)
+                if not infos:
+                    continue
+                idx = positions.get(imei, 0)
+                while idx < len(infos) and infos[idx][0] <= send_dt:
+                    idx += 1
+                positions[imei] = idx
+                if idx == 0:
+                    continue
+                latest = infos[idx - 1]
+                network_label = latest[1]
+                signal_quality = latest[2]
+                signal_dbm = latest[3]
+                updates.append((network_label, signal_quality, signal_dbm, row["__rowid__"]))
+
+            if updates:
+                conn.executemany(
+                    f'UPDATE "{table}" SET "tecnologia_celular" = ?, '
+                    f'"calidad_senal" = ?, "nivel_senal_dbm" = ? WHERE ROWID = ?',
+                    updates,
+                )
+            conn.commit()
+        finally:
+            conn.close()
+
+    return output_path
+
+
+__all__ = ["ensure_enriched_database"]

--- a/viz/mapa_recorridos.py
+++ b/viz/mapa_recorridos.py
@@ -23,6 +23,28 @@ from jinja2 import Template
 
 from src.ingestors.sqlite_records import ensure_db
 
+from .enriched_db import ensure_enriched_database
+from .utils import (
+    CSQ_BER_CANDIDATES,
+    CSQ_CANDIDATES,
+    IMEI_CANDIDATES,
+    LAT_CANDIDATES,
+    LON_CANDIDATES,
+    MCC_CANDIDATES,
+    MNC_CANDIDATES,
+    NETWORK_TYPE_CANDIDATES,
+    NETWORK_TYPE_MAP,
+    TIME_CANDIDATES,
+    classify_signal as _classify_signal,
+    detect_table as _detect_table,
+    first_existing as _first_existing,
+    load_table_schema as _load_table_schema,
+    normalize_operator as _normalize_operator,
+    parse_datetime as _parse_datetime,
+    safe_float as _safe_float,
+    safe_int as _safe_int,
+)
+
 # Tipos auxiliares -----------------------------------------------------------
 
 
@@ -53,14 +75,6 @@ class InfoRecord:
     csq: Optional[float] = None
     csq_ber: Optional[int] = None
 
-
-NETWORK_TYPE_MAP = {
-    0: "Sin servicio",
-    1: "2G",
-    2: "3G",
-    3: "4G",
-}
-
 NETWORK_COLORS = {
     "2G": "#1f77b4",
     "3G": "#ff7f0e",
@@ -77,179 +91,7 @@ OPERATOR_COLORS = {
     "Desconocido": "#7f7f7f",
 }
 
-IMEI_CANDIDATES = ["imei", "unique_id", "uniqueid", "device_imei"]
-LAT_CANDIDATES = [
-    "lat",
-    "latitude",
-    "latitude_deg",
-    "lat_decimal",
-    "lat_deg",
-]
-LON_CANDIDATES = [
-    "lon",
-    "longitude",
-    "longitude_deg",
-    "lon_decimal",
-    "lon_deg",
-]
-TIME_CANDIDATES = ["send_time", "gnss_utc_time", "timestamp", "created_at"]
-MCC_CANDIDATES = ["mcc", "mobile_country_code"]
-MNC_CANDIDATES = ["mnc", "mobile_network_code"]
-CSQ_CANDIDATES = ["csq", "csq_rssi", "csq_rsrp", "lte_csq"]
-CSQ_BER_CANDIDATES = ["csq_ber", "ber"]
-NETWORK_TYPE_CANDIDATES = ["network_type", "rat", "network"]
-
-
-# Utilidades de parsing ------------------------------------------------------
-
-
-def _parse_datetime(value: object) -> Optional[datetime]:
-    if value in (None, ""):
-        return None
-    text = str(value).strip()
-    if not text:
-        return None
-    for fmt in ("%Y%m%d%H%M%S", "%Y-%m-%d %H:%M:%S", "%Y/%m/%d %H:%M:%S"):
-        try:
-            return datetime.strptime(text, fmt)
-        except ValueError:
-            continue
-    try:
-        return datetime.fromisoformat(text)
-    except ValueError:
-        return None
-
-
-def _safe_float(value: object) -> Optional[float]:
-    if value in (None, ""):
-        return None
-    try:
-        return float(value)
-    except (TypeError, ValueError):
-        return None
-
-
-def _safe_int(value: object) -> Optional[int]:
-    if value in (None, ""):
-        return None
-    if isinstance(value, int):
-        return value
-    if isinstance(value, float):
-        if value != value:  # NaN check sin importar math.isnan
-            return None
-        return int(value)
-
-    text = str(value).strip()
-    if not text:
-        return None
-
-    try:
-        return int(text, 10)
-    except ValueError:
-        try:
-            return int(text, 0)
-        except ValueError:
-            cleaned = text.lstrip("0").strip() or "0"
-            try:
-                return int(cleaned, 10)
-            except ValueError:
-                return None
-
-
-def _normalize_operator(mcc: Optional[int], mnc: Optional[int]) -> str:
-    if mnc is None:
-        return "Desconocido"
-    if mcc is not None and mcc != 730:
-        return "Desconocido"
-    if mnc == 1:
-        return "Entel"
-    if mnc == 2:
-        return "Movistar"
-    if mnc == 3:
-        return "Claro"
-    if mnc == 9:
-        return "WOM"
-    return "Desconocido"
-
-
-def _csq_to_dbm(network_label: str, csq: Optional[float]) -> Optional[float]:
-    if csq is None:
-        return None
-    if network_label in {"2G", "3G"}:
-        if csq in {99, 199}:
-            return None
-        return csq * 2 - 113
-    if network_label == "4G":
-        if csq in {255, 511}:
-            return None
-        return csq - 140
-    return None
-
-
-def _classify_signal(network_label: str, csq: Optional[float], csq_ber: Optional[int]) -> Tuple[str, Optional[float]]:
-    dbm = _csq_to_dbm(network_label, csq)
-    if dbm is None:
-        return "Desconocida", None
-    quality: str
-    if dbm >= -80:
-        quality = "Excelente"
-    elif dbm >= -90:
-        quality = "Buena"
-    elif dbm >= -100:
-        quality = "Regular"
-    else:
-        quality = "Pésima"
-
-    if network_label == "3G" and csq_ber is not None:
-        # BER 5-7 se considera mala calidad.
-        if csq_ber >= 7:
-            quality = "Pésima"
-        elif csq_ber >= 5 and quality == "Excelente":
-            quality = "Buena"
-    return quality, dbm
-
-
-def _first_existing(candidates: Sequence[str], available: Iterable[str]) -> Optional[str]:
-    available_lower = {name.lower(): name for name in available}
-    for candidate in candidates:
-        if candidate.lower() in available_lower:
-            return available_lower[candidate.lower()]
-    return None
-
-
-def _detect_table(conn: sqlite3.Connection, report: str, model: str) -> str:
-    cursor = conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
-    names = [row[0] for row in cursor.fetchall()]
-    if not names:
-        raise ValueError("La base de datos no tiene tablas")
-    model_lower = model.lower()
-    report_lower = report.lower()
-    candidates = [
-        f"{report_lower}_{model_lower}",
-        f"{report_lower}_{model}",
-        f"{report}_{model_lower}",
-        f"{report}_{model}",
-        f"{report_lower}_records",
-        f"{report}_records",
-        f"{model_lower}_{report_lower}",
-        f"{report_lower}",
-    ]
-    existing_lower = {name.lower(): name for name in names}
-    for candidate in candidates:
-        if candidate.lower() in existing_lower:
-            return existing_lower[candidate.lower()]
-    if len(names) == 1:
-        return names[0]
-    raise ValueError(f"No se encontró una tabla para {report}/{model}. Tablas: {', '.join(names)}")
-
-
 # Lectura de datos -----------------------------------------------------------
-
-
-def _load_table_schema(conn: sqlite3.Connection, table: str) -> List[str]:
-    info = conn.execute(f'PRAGMA table_info("{table}")').fetchall()
-    return [row[1] for row in info]
-
 
 def _load_locations_from_db(
     db_path: Path,
@@ -281,12 +123,27 @@ def _load_locations_from_db(
 
         mcc_col = _first_existing(MCC_CANDIDATES, columns)
         mnc_col = _first_existing(MNC_CANDIDATES, columns)
+        csq_col = _first_existing(CSQ_CANDIDATES, columns)
+        ber_col = _first_existing(CSQ_BER_CANDIDATES, columns)
+        tech_col = "tecnologia_celular" if "tecnologia_celular" in columns else None
+        quality_col = "calidad_senal" if "calidad_senal" in columns else None
+        dbm_col = "nivel_senal_dbm" if "nivel_senal_dbm" in columns else None
 
         query_cols = {lat_col, lon_col, time_col, imei_col}
         if mcc_col:
             query_cols.add(mcc_col)
         if mnc_col:
             query_cols.add(mnc_col)
+        if csq_col:
+            query_cols.add(csq_col)
+        if ber_col:
+            query_cols.add(ber_col)
+        if tech_col:
+            query_cols.add(tech_col)
+        if quality_col:
+            query_cols.add(quality_col)
+        if dbm_col:
+            query_cols.add(dbm_col)
         query_cols.add("report_type") if "report_type" in columns else None
 
         select_clause = ", ".join(f'"{col}"' for col in query_cols)
@@ -296,14 +153,44 @@ def _load_locations_from_db(
         for row in conn.execute(sql, (imei,)):
             raw_lat = _safe_float(row[lat_col])
             raw_lon = _safe_float(row[lon_col])
-            lat = raw_lat if raw_lat is not None else raw_lon
-            lon = raw_lon if raw_lon is not None else raw_lat
             dt = _parse_datetime(row[time_col])
-            if lat is None or lon is None or dt is None:
+            if raw_lat is None or raw_lon is None or dt is None:
                 continue
             mcc = _safe_int(row[mcc_col]) if mcc_col else None
             mnc = _safe_int(row[mnc_col]) if mnc_col else None
+            lat, lon = raw_lat, raw_lon
+            if abs(lat) > 90 and abs(raw_lon) <= 90:
+                lat, lon = raw_lon, raw_lat
+            elif (
+                mcc == 730
+                and abs(lat) > 60
+                and 20 <= abs(lon) < 60
+            ):
+                lat, lon = lon, lat
+            if not (-90.0 <= lat <= 90.0 and -180.0 <= lon <= 180.0):
+                continue
+
             operator = _normalize_operator(mcc, mnc)
+            network_label = "Desconocida"
+            if tech_col:
+                raw_tech = row[tech_col]
+                if raw_tech not in (None, ""):
+                    network_label = str(raw_tech).strip()
+            signal_quality = "Desconocida"
+            if quality_col:
+                raw_quality = row[quality_col]
+                if raw_quality not in (None, ""):
+                    signal_quality = str(raw_quality).strip()
+            csq = _safe_float(row[csq_col]) if csq_col else None
+            csq_ber = _safe_int(row[ber_col]) if ber_col else None
+            signal_dbm = _safe_float(row[dbm_col]) if dbm_col else None
+            if signal_dbm is None and network_label not in (None, "", "Desconocida"):
+                computed_quality, computed_dbm = _classify_signal(
+                    network_label, csq, csq_ber
+                )
+                if signal_quality == "Desconocida":
+                    signal_quality = computed_quality
+                signal_dbm = computed_dbm
             raw_payload = {col: row[col] for col in row.keys()}
             points.append(
                 LocationPoint(
@@ -316,6 +203,11 @@ def _load_locations_from_db(
                     mcc=mcc,
                     mnc=mnc,
                     raw_payload=raw_payload,
+                    network_label=network_label or "Desconocida",
+                    signal_quality=signal_quality or "Desconocida",
+                    signal_dbm=signal_dbm,
+                    csq=csq,
+                    csq_ber=csq_ber,
                 )
             )
         return points
@@ -388,6 +280,9 @@ def _associate_info(points: List[LocationPoint], infos: List[InfoRecord]) -> Non
             idx += 1
         if current_info is None:
             continue
+        if point.network_label not in (None, "", "Desconocida"):
+            if point.signal_quality not in (None, "", "Desconocida") and point.signal_dbm is not None:
+                continue
         point.network_label = current_info.network_label
         point.csq = current_info.csq
         point.csq_ber = current_info.csq_ber
@@ -519,10 +414,26 @@ def render_interactive_map(
     operator_groups: Dict[str, FeatureGroup] = {}
     network_groups: Dict[str, FeatureGroup] = {}
 
+    all_days_group = FeatureGroup(name="Todos los días", overlay=True, show=True)
+    all_days_group.add_to(fmap)
+    day_groups["Todos los días"] = all_days_group
+
+    for operator_label, color in OPERATOR_COLORS.items():
+        group = FeatureGroup(name=f"Operador {operator_label}", overlay=True, show=True)
+        group.add_to(fmap)
+        operator_groups[operator_label] = group
+
+    for network_label, color in NETWORK_COLORS.items():
+        group = FeatureGroup(name=f"Tecnología {network_label}", overlay=True, show=True)
+        group.add_to(fmap)
+        network_groups[network_label] = group
+
     day_coords: Dict[str, List[Tuple[float, float]]] = defaultdict(list)
     operator_coords: Dict[str, List[Tuple[float, float]]] = defaultdict(list)
     network_coords: Dict[str, List[Tuple[float, float]]] = defaultdict(list)
     day_operator_counts: Dict[str, Counter] = defaultdict(Counter)
+    all_coords: List[Tuple[float, float]] = []
+    all_operator_counts: Counter = Counter()
 
     for point in points_sorted:
         day_label = point.send_time.date().isoformat()
@@ -565,10 +476,23 @@ def render_interactive_map(
                 tooltip=tooltip,
             ).add_to(group)
 
+        folium.CircleMarker(
+            location=(point.lat, point.lon),
+            radius=6,
+            color=operator_color,
+            weight=2,
+            fill=True,
+            fill_color=operator_color,
+            fill_opacity=0.85,
+            tooltip=tooltip,
+        ).add_to(all_days_group)
+
         day_coords[day_label].append((point.lat, point.lon))
         operator_coords[operator_label].append((point.lat, point.lon))
         network_coords[network_label].append((point.lat, point.lon))
         day_operator_counts[day_label][operator_label] += 1
+        all_coords.append((point.lat, point.lon))
+        all_operator_counts[operator_label] += 1
 
     for day_label, coords in day_coords.items():
         if len(coords) < 2:
@@ -579,6 +503,15 @@ def render_interactive_map(
         color = OPERATOR_COLORS.get(dominant_operator, OPERATOR_COLORS["Desconocido"])
         folium.PolyLine(coords, color=color, weight=4, opacity=0.6).add_to(
             day_groups[day_label]
+        )
+
+    if len(all_coords) >= 2:
+        dominant_operator, _ = max(
+            all_operator_counts.items(), key=lambda item: item[1]
+        )
+        color = OPERATOR_COLORS.get(dominant_operator, OPERATOR_COLORS["Desconocido"])
+        folium.PolyLine(all_coords, color=color, weight=4, opacity=0.6).add_to(
+            all_days_group
         )
 
     for operator_label, coords in operator_coords.items():
@@ -597,10 +530,32 @@ def render_interactive_map(
             network_groups[network_label]
         )
 
+    sorted_day_layers = [day_groups["Todos los días"]] + [
+        day_groups[key] for key in sorted(day_groups.keys()) if key != "Todos los días"
+    ]
+    sorted_operator_layers = [
+        operator_groups[key]
+        for key in OPERATOR_COLORS.keys()
+        if key in operator_groups
+    ] + [
+        operator_groups[key]
+        for key in sorted(operator_groups.keys())
+        if key not in OPERATOR_COLORS
+    ]
+    sorted_network_layers = [
+        network_groups[key]
+        for key in NETWORK_COLORS.keys()
+        if key in network_groups
+    ] + [
+        network_groups[key]
+        for key in sorted(network_groups.keys())
+        if key not in NETWORK_COLORS
+    ]
+
     grouped_layers = {
-        "Días": [day_groups[key] for key in sorted(day_groups.keys())],
-        "Operadores": [operator_groups[key] for key in sorted(operator_groups.keys())],
-        "Tecnologías": [network_groups[key] for key in sorted(network_groups.keys())],
+        "Días": sorted_day_layers,
+        "Operadores": sorted_operator_layers,
+        "Tecnologías": sorted_network_layers,
     }
     GroupedLayerControl(grouped_layers, collapsed=False).add_to(fmap)
 
@@ -630,8 +585,13 @@ def build_points(
     searched_paths: List[Path] = []
     for report in reports_to_use:
         db_path = base_dir / f"{report}_{model_clean}.db"
-        searched_paths.append(db_path)
-        points = _load_locations_from_db(db_path, report, model_clean, imei)
+        enriched_path = ensure_enriched_database(
+            report=report,
+            model=model_clean,
+            base_dir=base_dir,
+        )
+        searched_paths.append(enriched_path)
+        points = _load_locations_from_db(enriched_path, report, model_clean, imei)
         all_points.extend(points)
 
     if not all_points:

--- a/viz/utils.py
+++ b/viz/utils.py
@@ -1,0 +1,229 @@
+"""Funciones utilitarias compartidas entre los módulos de visualización."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Iterable, Optional, Sequence
+
+
+NETWORK_TYPE_MAP = {
+    0: "Sin servicio",
+    1: "2G",
+    2: "3G",
+    3: "4G",
+}
+
+IMEI_CANDIDATES = ["imei", "unique_id", "uniqueid", "device_imei"]
+LAT_CANDIDATES = [
+    "lat",
+    "latitude",
+    "latitude_deg",
+    "lat_decimal",
+    "lat_deg",
+]
+LON_CANDIDATES = [
+    "lon",
+    "longitude",
+    "longitude_deg",
+    "lon_decimal",
+    "lon_deg",
+]
+TIME_CANDIDATES = ["send_time", "gnss_utc_time", "timestamp", "created_at"]
+MCC_CANDIDATES = ["mcc", "mobile_country_code"]
+MNC_CANDIDATES = ["mnc", "mobile_network_code"]
+CSQ_CANDIDATES = ["csq", "csq_rssi", "csq_rsrp", "lte_csq"]
+CSQ_BER_CANDIDATES = ["csq_ber", "ber"]
+NETWORK_TYPE_CANDIDATES = ["network_type", "rat", "network"]
+
+
+def parse_datetime(value: object) -> Optional[datetime]:
+    """Convierte representaciones comunes de fecha/hora en ``datetime``.
+
+    Acepta cadenas en formatos típicos utilizados por los reportes Queclink,
+    como ``YYYYMMDDHHMMSS`` o ISO 8601. Devuelve ``None`` si el valor está
+    vacío o no puede interpretarse.
+    """
+
+    if value in (None, ""):
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    for fmt in ("%Y%m%d%H%M%S", "%Y-%m-%d %H:%M:%S", "%Y/%m/%d %H:%M:%S"):
+        try:
+            return datetime.strptime(text, fmt)
+        except ValueError:
+            continue
+    try:
+        return datetime.fromisoformat(text)
+    except ValueError:
+        return None
+
+
+def safe_float(value: object) -> Optional[float]:
+    """Convierte un valor en ``float`` manejando nulos y errores."""
+
+    if value in (None, ""):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def safe_int(value: object) -> Optional[int]:
+    """Convierte un valor en ``int`` aceptando distintos formatos."""
+
+    if value in (None, ""):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        if value != value:  # NaN
+            return None
+        return int(value)
+
+    text = str(value).strip()
+    if not text:
+        return None
+
+    try:
+        return int(text, 10)
+    except ValueError:
+        try:
+            return int(text, 0)
+        except ValueError:
+            cleaned = text.lstrip("0").strip() or "0"
+            try:
+                return int(cleaned, 10)
+            except ValueError:
+                return None
+
+
+def normalize_operator(mcc: Optional[int], mnc: Optional[int]) -> str:
+    """Retorna el nombre del operador a partir de MCC/MNC."""
+
+    if mnc is None:
+        return "Desconocido"
+    if mcc is not None and mcc != 730:
+        return "Desconocido"
+    if mnc == 1:
+        return "Entel"
+    if mnc == 2:
+        return "Movistar"
+    if mnc == 3:
+        return "Claro"
+    if mnc == 9:
+        return "WOM"
+    return "Desconocido"
+
+
+def csq_to_dbm(network_label: str, csq: Optional[float]) -> Optional[float]:
+    if csq is None:
+        return None
+    if network_label in {"2G", "3G"}:
+        if csq in {99, 199}:
+            return None
+        return csq * 2 - 113
+    if network_label == "4G":
+        if csq in {255, 511}:
+            return None
+        return csq - 140
+    return None
+
+
+def classify_signal(
+    network_label: str, csq: Optional[float], csq_ber: Optional[int]
+) -> tuple[str, Optional[float]]:
+    """Clasifica la calidad de señal y devuelve el valor en dBm."""
+
+    dbm = csq_to_dbm(network_label, csq)
+    if dbm is None:
+        return "Desconocida", None
+    if dbm >= -80:
+        quality = "Excelente"
+    elif dbm >= -90:
+        quality = "Buena"
+    elif dbm >= -100:
+        quality = "Regular"
+    else:
+        quality = "Pésima"
+
+    if network_label == "3G" and csq_ber is not None:
+        if csq_ber >= 7:
+            quality = "Pésima"
+        elif csq_ber >= 5 and quality == "Excelente":
+            quality = "Buena"
+
+    return quality, dbm
+
+
+def first_existing(
+    candidates: Sequence[str], available: Iterable[str]
+) -> Optional[str]:
+    """Busca la primera columna candidata presente en ``available``."""
+
+    available_lower = {name.lower(): name for name in available}
+    for candidate in candidates:
+        if candidate.lower() in available_lower:
+            return available_lower[candidate.lower()]
+    return None
+
+
+def detect_table(conn, report: str, model: str) -> str:
+    """Detecta el nombre de tabla apropiado para un reporte/modelo."""
+
+    cursor = conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    names = [row[0] for row in cursor.fetchall()]
+    if not names:
+        raise ValueError("La base de datos no tiene tablas")
+    model_lower = model.lower()
+    report_lower = report.lower()
+    candidates = [
+        f"{report_lower}_{model_lower}",
+        f"{report_lower}_{model}",
+        f"{report}_{model_lower}",
+        f"{report}_{model}",
+        f"{report_lower}_records",
+        f"{report}_records",
+        f"{model_lower}_{report_lower}",
+        f"{report_lower}",
+    ]
+    existing_lower = {name.lower(): name for name in names}
+    for candidate in candidates:
+        if candidate.lower() in existing_lower:
+            return existing_lower[candidate.lower()]
+    if len(names) == 1:
+        return names[0]
+    raise ValueError(
+        f"No se encontró una tabla para {report}/{model}. Tablas: {', '.join(names)}"
+    )
+
+
+def load_table_schema(conn, table: str) -> list[str]:
+    """Devuelve la lista de columnas definidas en ``table``."""
+
+    info = conn.execute(f'PRAGMA table_info("{table}")').fetchall()
+    return [row[1] for row in info]
+
+
+__all__ = [
+    "NETWORK_TYPE_MAP",
+    "IMEI_CANDIDATES",
+    "LAT_CANDIDATES",
+    "LON_CANDIDATES",
+    "TIME_CANDIDATES",
+    "MCC_CANDIDATES",
+    "MNC_CANDIDATES",
+    "CSQ_CANDIDATES",
+    "CSQ_BER_CANDIDATES",
+    "NETWORK_TYPE_CANDIDATES",
+    "classify_signal",
+    "csq_to_dbm",
+    "detect_table",
+    "first_existing",
+    "load_table_schema",
+    "normalize_operator",
+    "parse_datetime",
+    "safe_float",
+    "safe_int",
+]


### PR DESCRIPTION
## Summary
- factorizar utilidades compartidas para visualización y agregar un generador de bases `<reporte>_<modelo>_map.db` que fusiona GTERI/GTFRI con GTINF
- actualizar `viz/mapa_recorridos` para consumir la base enriquecida, corregir la orientación lat/lon y exponer la capa "Todos los días" junto con los filtros completos de operadores y tecnologías
- documentar el flujo actualizado y cubrir el enriquecimiento en las pruebas de visualización

## Testing
- pytest *(falla: pruebas de parser/esquemas existentes)*
- pytest tests/viz/test_mapa_recorridos.py *(omitida: folium no disponible en el entorno)*

------
https://chatgpt.com/codex/tasks/task_e_68f652f2b7788333a0e04ae37f6b8fd7