### PR TITLE
Fix coordinate normalization and enrich map operator metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,11 @@ Características destacadas:
 - Capas independientes por operador, tecnología y día.
 - Tooltips con IMEI, coordenadas, reporte origen, tecnología, clasificación de señal y valores
   de CSQ/BER cuando estén presentes.
+- Corrección automática de coordenadas cuando los reportes invierten latitud/longitud, incluso
+  si la trama no incluye códigos MCC.
+- Los recorridos y filtros se construyen exclusivamente a partir de las bases enriquecidas
+  `<reporte>_<modelo>_map.db`, que ahora incluyen una columna `operador` con el nombre del
+  carrier normalizado (Entel, Movistar, Claro, WOM o Desconocido).
 - Filtros `--day`, `--operator`, `--network` y `--report`, todos compatibles con la palabra
   clave `All` para desactivar la restricción.
 

--- a/tests/viz/test_mapa_recorridos.py
+++ b/tests/viz/test_mapa_recorridos.py
@@ -4,8 +4,6 @@ from pathlib import Path
 
 import pytest
 
-pytest.importorskip("folium")
-
 from viz.mapa_recorridos import (
     build_points,
     render_interactive_map,
@@ -165,7 +163,7 @@ def test_enriched_database_creates_columns_and_values(tmp_path: Path):
     conn = sqlite3.connect(enriched_path)
     try:
         rows = conn.execute(
-            'SELECT tecnologia_celular, calidad_senal, nivel_senal_dbm '
+            'SELECT tecnologia_celular, calidad_senal, nivel_senal_dbm, operador '
             'FROM "gteri_gv350ceu" ORDER BY send_time'
         ).fetchall()
     finally:
@@ -174,11 +172,13 @@ def test_enriched_database_creates_columns_and_values(tmp_path: Path):
     tecnologias = [row[0] for row in rows]
     calidades = [row[1] for row in rows]
     niveles = [row[2] for row in rows]
+    operadores = [row[3] for row in rows]
 
     assert tecnologias == ["4G", "4G", "2G"]
     assert calidades == ["Excelente", "Excelente", "Buena"]
     assert niveles[0] == pytest.approx(20.0)
     assert niveles[2] == pytest.approx(-89.0)
+    assert operadores == ["Movistar", "Movistar", "Movistar"]
 
 
 def test_build_points_uses_enriched_database(tmp_path: Path):
@@ -199,6 +199,42 @@ def test_build_points_uses_enriched_database(tmp_path: Path):
     assert [p.operator for p in points] == ["Movistar"] * 3
     assert points[0].lat == pytest.approx(-33.45)
     assert points[0].lon == pytest.approx(-70.66)
+
+
+def test_build_points_swaps_coordinates_without_mcc(tmp_path: Path):
+    model = "gv350ceu"
+    imei = "987654321098765"
+    base_dir = tmp_path
+
+    gteri_path = base_dir / f"gteri_{model}.db"
+    conn = sqlite3.connect(gteri_path)
+    conn.execute(
+        f'CREATE TABLE "gteri_{model}" ('
+        'imei TEXT, send_time TEXT, lat REAL, lon REAL, mnc TEXT)'
+    )
+    conn.executemany(
+        f'INSERT INTO "gteri_{model}" (imei, send_time, lat, lon, mnc) '
+        'VALUES (?, ?, ?, ?, ?)',
+        [
+            (imei, "202510100000", -70.66, -33.45, "0002"),
+            (imei, "202510100500", -70.65, -33.46, "0002"),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    ensure_enriched_database(report="gteri", model=model, base_dir=base_dir)
+
+    points = build_points(
+        model=model,
+        imei=imei,
+        base_dir=base_dir,
+        reports=["gteri"],
+    )
+
+    assert len(points) == 2
+    assert all(-40.0 < p.lat < -20.0 for p in points)
+    assert all(-80.0 < p.lon < -60.0 for p in points)
 
 
 def test_render_interactive_map_includes_all_filters(tmp_path: Path):

--- a/viz/enriched_db.py
+++ b/viz/enriched_db.py
@@ -14,6 +14,8 @@ from .utils import (
     CSQ_BER_CANDIDATES,
     CSQ_CANDIDATES,
     IMEI_CANDIDATES,
+    MCC_CANDIDATES,
+    MNC_CANDIDATES,
     NETWORK_TYPE_CANDIDATES,
     NETWORK_TYPE_MAP,
     TIME_CANDIDATES,
@@ -21,6 +23,7 @@ from .utils import (
     detect_table,
     first_existing,
     load_table_schema,
+    normalize_operator,
     parse_datetime,
     safe_float,
     safe_int,
@@ -121,6 +124,7 @@ def ensure_enriched_database(*, report: str, model: str, base_dir: Path | str) -
             _ensure_column(conn, table, "tecnologia_celular", "TEXT")
             _ensure_column(conn, table, "calidad_senal", "TEXT")
             _ensure_column(conn, table, "nivel_senal_dbm", "REAL")
+            _ensure_column(conn, table, "operador", "TEXT")
 
             columns = load_table_schema(conn, table)
             imei_col = first_existing(IMEI_CANDIDATES, columns)
@@ -132,48 +136,70 @@ def ensure_enriched_database(*, report: str, model: str, base_dir: Path | str) -
                 f'UPDATE "{table}" SET "tecnologia_celular" = "Desconocida", '
                 '"calidad_senal" = "Desconocida", "nivel_senal_dbm" = NULL'
             )
+            conn.execute(f'UPDATE "{table}" SET "operador" = "Desconocido"')
 
             gtinf_lookup = _load_gtinf_lookup(gtinf_path, model_clean)
             if not gtinf_lookup:
                 conn.commit()
-                return output_path
-
-            select_sql = (
-                f'SELECT ROWID as __rowid__, "{imei_col}" as imei_value, '
-                f'"{time_col}" as send_value FROM "{table}" ORDER BY "{time_col}"'
-            )
-            updates: List[Tuple[str, str, Optional[float], int]] = []
-            positions: Dict[str, int] = defaultdict(int)
-
-            for row in conn.execute(select_sql):
-                imei_val = row["imei_value"]
-                imei = str(imei_val).strip() if imei_val not in (None, "") else None
-                if not imei:
-                    continue
-                send_dt = parse_datetime(row["send_value"])
-                if send_dt is None:
-                    continue
-                infos = gtinf_lookup.get(imei)
-                if not infos:
-                    continue
-                idx = positions.get(imei, 0)
-                while idx < len(infos) and infos[idx][0] <= send_dt:
-                    idx += 1
-                positions[imei] = idx
-                if idx == 0:
-                    continue
-                latest = infos[idx - 1]
-                network_label = latest[1]
-                signal_quality = latest[2]
-                signal_dbm = latest[3]
-                updates.append((network_label, signal_quality, signal_dbm, row["__rowid__"]))
-
-            if updates:
-                conn.executemany(
-                    f'UPDATE "{table}" SET "tecnologia_celular" = ?, '
-                    f'"calidad_senal" = ?, "nivel_senal_dbm" = ? WHERE ROWID = ?',
-                    updates,
+            else:
+                select_sql = (
+                    f'SELECT ROWID as __rowid__, "{imei_col}" as imei_value, '
+                    f'"{time_col}" as send_value FROM "{table}" ORDER BY "{time_col}"'
                 )
+                updates: List[Tuple[str, str, Optional[float], int]] = []
+                positions: Dict[str, int] = defaultdict(int)
+
+                for row in conn.execute(select_sql):
+                    imei_val = row["imei_value"]
+                    imei = str(imei_val).strip() if imei_val not in (None, "") else None
+                    if not imei:
+                        continue
+                    send_dt = parse_datetime(row["send_value"])
+                    if send_dt is None:
+                        continue
+                    infos = gtinf_lookup.get(imei)
+                    if not infos:
+                        continue
+                    idx = positions.get(imei, 0)
+                    while idx < len(infos) and infos[idx][0] <= send_dt:
+                        idx += 1
+                    positions[imei] = idx
+                    if idx == 0:
+                        continue
+                    latest = infos[idx - 1]
+                    network_label = latest[1]
+                    signal_quality = latest[2]
+                    signal_dbm = latest[3]
+                    updates.append((network_label, signal_quality, signal_dbm, row["__rowid__"]))
+
+                if updates:
+                    conn.executemany(
+                        f'UPDATE "{table}" SET "tecnologia_celular" = ?, '
+                        f'"calidad_senal" = ?, "nivel_senal_dbm" = ? WHERE ROWID = ?',
+                        updates,
+                    )
+
+            # Actualizamos el operador utilizando MCC/MNC
+            columns = load_table_schema(conn, table)
+            mcc_col = first_existing(MCC_CANDIDATES, columns)
+            mnc_col = first_existing(MNC_CANDIDATES, columns)
+            if mnc_col:
+                select_sql = (
+                    f'SELECT ROWID as __rowid__, '
+                    f'"{mcc_col}" as mcc_value, "{mnc_col}" as mnc_value '
+                    f'FROM "{table}"'
+                )
+                operator_updates: List[Tuple[str, int]] = []
+                for row in conn.execute(select_sql):
+                    mcc = safe_int(row["mcc_value"]) if mcc_col else None
+                    mnc = safe_int(row["mnc_value"])
+                    operator = normalize_operator(mcc, mnc)
+                    operator_updates.append((operator, row["__rowid__"]))
+                if operator_updates:
+                    conn.executemany(
+                        f'UPDATE "{table}" SET "operador" = ? WHERE ROWID = ?',
+                        operator_updates,
+                    )
             conn.commit()
         finally:
             conn.close()

--- a/viz/mapa_recorridos.py
+++ b/viz/mapa_recorridos.py
@@ -13,13 +13,31 @@ try:  # pragma: no cover - dependencia opcional en tiempo de ejecución
     import folium
     from folium import FeatureGroup, Map
     from folium.plugins import GroupedLayerControl
+    _FOLIUM_IMPORT_ERROR: ModuleNotFoundError | None = None
 except ModuleNotFoundError as exc:  # pragma: no cover - entorno sin folium
-    raise ModuleNotFoundError(
+    folium = None  # type: ignore[assignment]
+    FeatureGroup = Map = GroupedLayerControl = None  # type: ignore[assignment]
+    _FOLIUM_IMPORT_ERROR = ModuleNotFoundError(
         "folium no está instalado. Ejecuta 'pip install folium pytz python-dateutil'"
-    ) from exc
+    )
 
-from branca.element import MacroElement
-from jinja2 import Template
+try:  # pragma: no cover - dependencia opcional
+    from branca.element import MacroElement
+except ModuleNotFoundError:  # pragma: no cover - entorno sin branca
+    MacroElement = object  # type: ignore[assignment]
+    if '_FOLIUM_IMPORT_ERROR' in globals() and _FOLIUM_IMPORT_ERROR is None:
+        _FOLIUM_IMPORT_ERROR = ModuleNotFoundError(
+            "branca no está instalado. Ejecuta 'pip install folium pytz python-dateutil'"
+        )
+
+try:  # pragma: no cover - dependencia opcional
+    from jinja2 import Template
+except ModuleNotFoundError:  # pragma: no cover - entorno sin jinja2
+    Template = None  # type: ignore[assignment]
+    if '_FOLIUM_IMPORT_ERROR' in globals() and _FOLIUM_IMPORT_ERROR is None:
+        _FOLIUM_IMPORT_ERROR = ModuleNotFoundError(
+            "jinja2 no está instalado. Ejecuta 'pip install folium pytz python-dateutil'"
+        )
 
 from src.ingestors.sqlite_records import ensure_db
 
@@ -91,6 +109,36 @@ OPERATOR_COLORS = {
     "Desconocido": "#7f7f7f",
 }
 
+# Utilidades internas --------------------------------------------------------
+
+
+def _valid_coordinates(lat: float, lon: float) -> bool:
+    return -90.0 <= lat <= 90.0 and -180.0 <= lon <= 180.0
+
+
+def _swap_coordinates_if_needed(
+    lat: float, lon: float, mcc: Optional[int]
+) -> Tuple[float, float]:
+    candidate_lat, candidate_lon = lon, lat
+    swap_valid = _valid_coordinates(candidate_lat, candidate_lon)
+
+    if abs(lat) > 90.0 and abs(lon) <= 90.0 and swap_valid:
+        return candidate_lat, candidate_lon
+
+    if mcc == 730 and abs(lat) > 60.0 and abs(lon) < 80.0 and swap_valid:
+        return candidate_lat, candidate_lon
+
+    if abs(lat) > 60.0 and swap_valid and not (-60.0 <= lat <= 60.0):
+        if -60.0 <= candidate_lat <= 60.0:
+            return candidate_lat, candidate_lon
+
+    return lat, lon
+
+
+def _require_folium() -> None:
+    if _FOLIUM_IMPORT_ERROR is not None:
+        raise _FOLIUM_IMPORT_ERROR
+
 # Lectura de datos -----------------------------------------------------------
 
 def _load_locations_from_db(
@@ -128,6 +176,7 @@ def _load_locations_from_db(
         tech_col = "tecnologia_celular" if "tecnologia_celular" in columns else None
         quality_col = "calidad_senal" if "calidad_senal" in columns else None
         dbm_col = "nivel_senal_dbm" if "nivel_senal_dbm" in columns else None
+        operator_col = "operador" if "operador" in columns else None
 
         query_cols = {lat_col, lon_col, time_col, imei_col}
         if mcc_col:
@@ -144,6 +193,8 @@ def _load_locations_from_db(
             query_cols.add(quality_col)
         if dbm_col:
             query_cols.add(dbm_col)
+        if operator_col:
+            query_cols.add(operator_col)
         query_cols.add("report_type") if "report_type" in columns else None
 
         select_clause = ", ".join(f'"{col}"' for col in query_cols)
@@ -158,19 +209,17 @@ def _load_locations_from_db(
                 continue
             mcc = _safe_int(row[mcc_col]) if mcc_col else None
             mnc = _safe_int(row[mnc_col]) if mnc_col else None
-            lat, lon = raw_lat, raw_lon
-            if abs(lat) > 90 and abs(raw_lon) <= 90:
-                lat, lon = raw_lon, raw_lat
-            elif (
-                mcc == 730
-                and abs(lat) > 60
-                and 20 <= abs(lon) < 60
-            ):
-                lat, lon = lon, lat
+            lat, lon = _swap_coordinates_if_needed(raw_lat, raw_lon, mcc)
             if not (-90.0 <= lat <= 90.0 and -180.0 <= lon <= 180.0):
                 continue
 
-            operator = _normalize_operator(mcc, mnc)
+            operator = ""
+            if operator_col:
+                raw_operator = row[operator_col]
+                if raw_operator not in (None, ""):
+                    operator = str(raw_operator).strip()
+            if not operator:
+                operator = _normalize_operator(mcc, mnc)
             network_label = "Desconocida"
             if tech_col:
                 raw_tech = row[tech_col]
@@ -402,6 +451,7 @@ def render_interactive_map(
     *,
     tiles: str = "OpenStreetMap",
 ) -> None:
+    _require_folium()
     if not points:
         raise ValueError("No hay puntos para representar en el mapa")
 


### PR DESCRIPTION
## Summary
- populate the `<reporte>_<modelo>_map.db` copies with an `operador` column derived from MCC/MNC and keep signal metadata in sync
- improve the map loader to correct swapped latitude/longitude readings, prefer the stored operator labels, and tolerate missing folium/branca/jinja2 dependencies until rendering time
- expand regression tests and README notes to cover the new operator column and coordinate normalization behaviour

## Testing
- pytest tests/viz/test_mapa_recorridos.py -q

------
https://chatgpt.com/codex/tasks/task_e_68f685e4db0483338c18d8d99d1cb90f