### PR TITLE
Handle IMEI formatting differences in map queries

### DIFF
--- a/tests/viz/test_mapa_recorridos.py
+++ b/tests/viz/test_mapa_recorridos.py
@@ -198,6 +198,70 @@ def test_build_points_uses_enriched_database(tmp_path: Path):
     assert [p.signal_quality for p in points] == ["Excelente", "Excelente", "Buena"]
     assert [p.operator for p in points] == ["Movistar"] * 3
     assert points[0].lat == pytest.approx(-33.45)
+
+
+def test_build_points_accepts_whitespace_imei(tmp_path: Path):
+    base_dir = tmp_path
+    model = "gv310lau"
+    imei = "868589060824888"
+
+    gteri_path = base_dir / f"gteri_{model}.db"
+    conn = sqlite3.connect(gteri_path)
+    conn.execute(
+        f"""
+        CREATE TABLE "gteri_{model}" (
+            imei TEXT,
+            send_time TEXT,
+            lat REAL,
+            lon REAL,
+            mcc TEXT,
+            mnc TEXT,
+            report_type TEXT
+        )
+        """
+    )
+    conn.execute(
+        f'INSERT INTO "gteri_{model}" (imei, send_time, lat, lon, mcc, mnc, report_type) '
+        'VALUES (?, ?, ?, ?, ?, ?, ?)',
+        (f"  {imei}\r\n", "202401020304", -33.45, -70.66, "0730", "0002", "GTERI"),
+    )
+    conn.commit()
+    conn.close()
+
+    gtinf_path = base_dir / f"gtinf_{model}.db"
+    conn = sqlite3.connect(gtinf_path)
+    conn.execute(
+        f"""
+        CREATE TABLE "gtinf_{model}" (
+            imei TEXT,
+            send_time TEXT,
+            network_type INTEGER,
+            csq REAL,
+            csq_ber INTEGER
+        )
+        """
+    )
+    conn.execute(
+        f'INSERT INTO "gtinf_{model}" (imei, send_time, network_type, csq, csq_ber) '
+        'VALUES (?, ?, ?, ?, ?)',
+        (f"\t{imei}   ", "202401020200", 3, 160, None),
+    )
+    conn.commit()
+    conn.close()
+
+    points = build_points(
+        model=model,
+        imei=imei,
+        base_dir=base_dir,
+        reports=["gteri"],
+    )
+
+    assert len(points) == 1
+    point = points[0]
+    assert point.lat == pytest.approx(-33.45)
+    assert point.operator == "Movistar"
+    assert point.network_label == "4G"
+    assert point.signal_quality == "Excelente"
     assert points[0].lon == pytest.approx(-70.66)
 
 

--- a/viz/mapa_recorridos.py
+++ b/viz/mapa_recorridos.py
@@ -139,6 +139,18 @@ def _require_folium() -> None:
     if _FOLIUM_IMPORT_ERROR is not None:
         raise _FOLIUM_IMPORT_ERROR
 
+def _normalized_imei_value(value: str) -> str:
+    return "".join(ch for ch in str(value).strip() if ch.isalnum())
+
+
+def _normalized_imei_expression(column: str) -> str:
+    base = f'trim(CAST("{column}" AS TEXT))'
+    without_breaks = (
+        f"replace(replace(replace(replace({base}, char(10), ''), char(13), ''), char(9), ''), ' ', '')"
+    )
+    return f"replace({without_breaks}, '-', '')"
+
+
 # Lectura de datos -----------------------------------------------------------
 
 def _load_locations_from_db(
@@ -197,11 +209,16 @@ def _load_locations_from_db(
             query_cols.add(operator_col)
         query_cols.add("report_type") if "report_type" in columns else None
 
+        imei_expr = _normalized_imei_expression(imei_col)
         select_clause = ", ".join(f'"{col}"' for col in query_cols)
-        sql = f'SELECT {select_clause} FROM "{table}" WHERE "{imei_col}" = ? ORDER BY "{time_col}"'
+        sql = (
+            f'SELECT {select_clause} FROM "{table}" '
+            f"WHERE {imei_expr} = ? ORDER BY \"{time_col}\""
+        )
 
         points: List[LocationPoint] = []
-        for row in conn.execute(sql, (imei,)):
+        normalized_imei = _normalized_imei_value(imei)
+        for row in conn.execute(sql, (normalized_imei,)):
             raw_lat = _safe_float(row[lat_col])
             raw_lon = _safe_float(row[lon_col])
             dt = _parse_datetime(row[time_col])
@@ -288,11 +305,16 @@ def _load_gtinf_records(db_path: Path, model: str, imei: str) -> List[InfoRecord
     if ber_col:
         query_cols.add(ber_col)
 
+    imei_expr = _normalized_imei_expression(imei_col)
     select_clause = ", ".join(f'"{col}"' for col in query_cols)
-    sql = f'SELECT {select_clause} FROM "{table}" WHERE "{imei_col}" = ? ORDER BY "{time_col}"'
+    sql = (
+        f'SELECT {select_clause} FROM "{table}" '
+        f"WHERE {imei_expr} = ? ORDER BY \"{time_col}\""
+    )
 
+    normalized_imei = _normalized_imei_value(imei)
     info_records: List[InfoRecord] = []
-    for row in conn.execute(sql, (imei,)):
+    for row in conn.execute(sql, (normalized_imei,)):
         dt = _parse_datetime(row[time_col])
         if dt is None:
             continue


### PR DESCRIPTION
## Summary
- normalize IMEI filters when reading GTERI/GTFRI records so lookups tolerate whitespace and punctuation in the stored value
- reuse the normalized filters for GTINF joins to keep signal enrichment working with messy IMEI fields
- cover the regression with a unit test that stores IMEIs padded with whitespace and tab characters

## Testing
- pytest tests/viz/test_mapa_recorridos.py

------
https://chatgpt.com/codex/tasks/task_e_68f69d98ac44833383978c874b3fcf00