### PR TITLE
Fix GV310LAU GTERI DOP parsing when mask bits are unset

### DIFF
--- a/queclink/parser.py
+++ b/queclink/parser.py
@@ -369,7 +369,13 @@ def parse_line(
     result: dict[str, object] = {}
     for index, field in enumerate(spec.fields):
         remaining = spec.fields[index + 1 :]
-        value = _parse_field(field, stream, context, remaining_fields=remaining)
+        value = _parse_field(
+            field,
+            stream,
+            context,
+            remaining_fields=remaining,
+            config=spec.config,
+        )
         if value is not _SKIP:
             result[field.name] = value
 
@@ -383,15 +389,58 @@ def parse_line(
     return result
 
 
+def _should_force_parse(
+    field: FieldSpec,
+    stream: _TokenStream,
+    config: Optional[dict[str, object]],
+) -> bool:
+    if not config:
+        return False
+
+    tolerated_raw = config.get("tolerate_unmasked_position_fields")
+    if not tolerated_raw:
+        return False
+
+    if tolerated_raw is True:
+        tolerated = {"sats_in_use", "hdop", "vdop", "pdop"}
+    elif isinstance(tolerated_raw, str):
+        tolerated = {tolerated_raw}
+    elif isinstance(tolerated_raw, (set, tuple, list)):
+        tolerated = {str(item) for item in tolerated_raw}
+    else:
+        return False
+
+    name = getattr(field, "name", None)
+    if not name or name not in tolerated:
+        return False
+
+    token = stream.peek()
+    if token in (None, ""):
+        return False
+
+    text = str(token).strip()
+    if not text:
+        return False
+
+    if name == "sats_in_use":
+        pattern = r"\d{1,2}"
+    else:
+        pattern = r"-?\d+(?:\.\d+)?"
+
+    return re.fullmatch(pattern, text) is not None
+
+
 def _parse_field(
     field: FieldSpec,
     stream: _TokenStream,
     context: _ParseContext,
     *,
     remaining_fields: Sequence[FieldSpec] = (),
+    config: Optional[dict[str, object]] = None,
 ):
     if not _should_parse(field, context):
-        return _SKIP
+        if not _should_force_parse(field, stream, config):
+            return _SKIP
 
     required_tokens = _minimum_required_tokens(remaining_fields, context)
     if field.optional and stream.remaining() <= required_tokens:
@@ -404,7 +453,7 @@ def _parse_field(
         count = _repeat_count(field, context)
         if (count is None or count <= 0) and field.optional:
             return _SKIP
-        return _parse_group(field, stream, context, count=count)
+        return _parse_group(field, stream, context, count=count, config=config)
 
     if stream.remaining() <= 0:
         if field.optional:
@@ -446,6 +495,7 @@ def _parse_group(
     context: _ParseContext,
     *,
     count: Optional[int] = None,
+    config: Optional[dict[str, object]] = None,
 ):
     if count is None:
         count = _repeat_count(field, context)
@@ -462,6 +512,7 @@ def _parse_group(
                 stream,
                 child_context,
                 remaining_fields=nested_remaining,
+                config=config,
             )
             if value is not _SKIP:
                 item[nested.name] = value

--- a/spec/gv310lau/gteri.yml
+++ b/spec/gv310lau/gteri.yml
@@ -10,6 +10,11 @@ config:
   # Modo de interpretación del bit 3 de position_append_mask: "pdop" o "accuracy_factor"
   # Desde v9.00 se documenta "GNSS accuracy factor" como opción.
   posmask_bit3_mode: "pdop"
+  # Algunos firmwares envían HDOP/VDOP/PDOP aun con los bits apagados.
+  tolerate_unmasked_position_fields:
+    - hdop
+    - vdop
+    - pdop
 
 version_field:
   name: full_protocol_version

--- a/tests/gv310lau/test_gteri_spec_parser.py
+++ b/tests/gv310lau/test_gteri_spec_parser.py
@@ -1,0 +1,23 @@
+import pytest
+
+from queclink.parser import parse_line
+
+RAW_WITH_UNMASKED_DOPS = (
+    "+RESP:GTERI,6E0902,868589060824888,GV310LAU,00000002,14778,10,1,1,12.0,40,381.6," \
+    "-70.331679,-27.366874,20251016235959,0730,0002,012F,08164920,09,12,0.83,1.64,1.83,600.0," \
+    "0000015:21:09,,,,100,220100,0,0,20251017000001,3111$"
+)
+
+
+def test_parse_line_handles_unmasked_dops_gv310lau():
+    data = parse_line(RAW_WITH_UNMASKED_DOPS)
+    assert data["sats_in_use"] == 12
+    assert data["hdop"] == pytest.approx(0.83)
+    assert data["vdop"] == pytest.approx(1.64)
+    assert data["pdop"] == pytest.approx(1.83)
+    assert data["mileage_km"] == pytest.approx(600.0)
+    assert data["hour_meter"] == "0000015:21:09"
+    assert data["device_status"] == "220100"
+    assert data["uart_device_type"] == 0
+    assert data["send_time"] == "20251017000001"
+    assert data["count_hex"] == "3111"


### PR DESCRIPTION
## Summary
- allow the parser to tolerate HDOP/VDOP/PDOP tokens even when the GV310LAU position append mask does not enable them
- enable the behaviour through the GV310LAU GTERI spec configuration
- add a regression test that exercises the unmasked DOP scenario and keeps send_time/count_hex aligned

## Testing
- pytest tests/gv310lau/test_gteri_spec_parser.py

------
https://chatgpt.com/codex/tasks/task_e_68f779a9e4ac833399597c38fe6c72b6