### PR TITLE
Adjust operator/technology filters to depend on day selection

### DIFF
--- a/tests/viz/test_mapa_recorridos.py
+++ b/tests/viz/test_mapa_recorridos.py
@@ -152,6 +152,47 @@ def test_filter_points_accepts_all_keyword_for_every_filter():
     assert _filter_points(points, day="all") == points
 
 
+def test_filter_points_day_filter_has_priority():
+    day_one_point = _make_point(0, operator="Claro", network="3G")
+    day_two_point = _make_point(86400, operator="Claro", network="3G")
+    extra_day_two = _make_point(86400 + 60, operator="Entel", network="2G")
+
+    points = [day_one_point, day_two_point, extra_day_two]
+
+    result = _filter_points(
+        points,
+        day="2025-10-10",
+        operators=["Claro"],
+        networks=["3G"],
+    )
+
+    assert result == [day_one_point]
+
+
+def test_filter_points_operator_and_network_depend_on_day():
+    points = [
+        _make_point(0, operator="Claro", network="3G"),
+        _make_point(86400, operator="Entel", network="4G"),
+    ]
+
+    assert _filter_points(points, operators=["Claro"]) == points
+    assert _filter_points(points, networks=["3G"]) == points
+
+
+def test_filter_points_returns_empty_when_combination_not_found():
+    points = [
+        _make_point(0, operator="Claro", network="3G"),
+        _make_point(60, operator="Claro", network="3G"),
+    ]
+
+    assert _filter_points(
+        points,
+        day="2025-10-10",
+        operators=["Entel"],
+        networks=["4G"],
+    ) == []
+
+
 def test_enriched_database_creates_columns_and_values(tmp_path: Path):
     base_dir = _prepare_sample_databases(tmp_path)
 

--- a/viz/mapa_recorridos.py
+++ b/viz/mapa_recorridos.py
@@ -400,22 +400,17 @@ def _filter_points(
     operators: Optional[Sequence[str]] = None,
     networks: Optional[Sequence[str]] = None,
 ) -> List[LocationPoint]:
-    result = []
+    """Filtra puntos aplicando prioridad al día antes que otros filtros."""
 
     normalized_ops = (
         {op.strip().lower() for op in operators if op is not None}
         if operators
         else None
     )
-    operator_set = None if not normalized_ops or "all" in normalized_ops else normalized_ops
-
     normalized_networks = (
         {nt.strip().lower() for nt in networks if nt is not None}
         if networks
         else None
-    )
-    network_set = (
-        None if not normalized_networks or "all" in normalized_networks else normalized_networks
     )
 
     day_value: Optional[datetime] = None
@@ -426,12 +421,31 @@ def _filter_points(
                 day_value = datetime.strptime(day_clean, "%Y-%m-%d")
             except ValueError as exc:  # pragma: no cover - validación de CLI
                 raise ValueError("El día debe tener formato YYYY-MM-DD") from exc
-    for point in points:
-        if day_value and point.send_time.date() != day_value.date():
+
+    # Priorizamos la selección por día. Si no se especifica un día, se mantienen todos
+    # los puntos disponibles y los filtros complementarios quedan deshabilitados.
+    if day_value is None:
+        day_filtered = list(points)
+        operator_set = None
+        network_set = None
+    else:
+        day_filtered = [
+            point for point in points if point.send_time.date() == day_value.date()
+        ]
+        operator_set = (
+            None if not normalized_ops or "all" in normalized_ops else normalized_ops
+        )
+        network_set = (
+            None
+            if not normalized_networks or "all" in normalized_networks
+            else normalized_networks
+        )
+
+    result: List[LocationPoint] = []
+    for point in day_filtered:
+        if operator_set and (point.operator or "").lower() not in operator_set:
             continue
-        if operator_set and point.operator.lower() not in operator_set:
-            continue
-        if network_set and point.network_label.lower() not in network_set:
+        if network_set and (point.network_label or "").lower() not in network_set:
             continue
         result.append(point)
     return result


### PR DESCRIPTION
## Summary
- prioritize day filtering before applying operator or technology constraints
- ensure operator and technology filters are ignored until a day is chosen
- extend filter tests to cover day priority and empty results

## Testing
- pytest tests/viz/test_mapa_recorridos.py

------
https://chatgpt.com/codex/tasks/task_e_68f7892fe8b08333b1462d500c576bab