### PR TITLE
Fix interactive map filters and IMEI table detection

### DIFF
--- a/viz/enriched_db.py
+++ b/viz/enriched_db.py
@@ -38,7 +38,7 @@ def _ensure_column(conn: sqlite3.Connection, table: str, column: str, definition
 
 
 def _load_gtinf_lookup(
-    gtinf_path: Path, model: str
+    gtinf_path: Path, model: str, imei: str | None = None
 ) -> Dict[str, List[Tuple[datetime, str, str, Optional[float]]]]:
     if not gtinf_path.exists():
         return {}
@@ -46,7 +46,7 @@ def _load_gtinf_lookup(
     conn = ensure_db(gtinf_path)
     conn.row_factory = sqlite3.Row
     try:
-        table = detect_table(conn, "gtinf", model)
+        table = detect_table(conn, "gtinf", model, imei)
         columns = load_table_schema(conn, table)
         imei_col = first_existing(IMEI_CANDIDATES, columns)
         time_col = first_existing(TIME_CANDIDATES, columns)
@@ -90,7 +90,9 @@ def _resolve_output_path(base_dir: Path, report: str, model: str) -> Path:
     return base_dir / name
 
 
-def ensure_enriched_database(*, report: str, model: str, base_dir: Path | str) -> Path:
+def ensure_enriched_database(
+    *, report: str, model: str, base_dir: Path | str, imei: str | None = None
+) -> Path:
     """Genera (si es necesario) una copia enriquecida de la base de recorridos."""
 
     base_path = Path(base_dir)
@@ -120,7 +122,7 @@ def ensure_enriched_database(*, report: str, model: str, base_dir: Path | str) -
         conn = ensure_db(output_path)
         conn.row_factory = sqlite3.Row
         try:
-            table = detect_table(conn, report_clean, model_clean)
+            table = detect_table(conn, report_clean, model_clean, imei)
             _ensure_column(conn, table, "tecnologia_celular", "TEXT")
             _ensure_column(conn, table, "calidad_senal", "TEXT")
             _ensure_column(conn, table, "nivel_senal_dbm", "REAL")
@@ -138,7 +140,7 @@ def ensure_enriched_database(*, report: str, model: str, base_dir: Path | str) -
             )
             conn.execute(f'UPDATE "{table}" SET "operador" = "Desconocido"')
 
-            gtinf_lookup = _load_gtinf_lookup(gtinf_path, model_clean)
+            gtinf_lookup = _load_gtinf_lookup(gtinf_path, model_clean, imei)
             if not gtinf_lookup:
                 conn.commit()
             else:

--- a/viz/mapa_recorridos.py
+++ b/viz/mapa_recorridos.py
@@ -190,7 +190,7 @@ def _load_locations_from_db(
     _register_sqlite_helpers(conn)
     conn.row_factory = sqlite3.Row
     try:
-        table = _detect_table(conn, report, model)
+        table = _detect_table(conn, report, model, imei)
         columns = _load_table_schema(conn, table)
 
         imei_col = _first_existing(IMEI_CANDIDATES, columns)
@@ -313,7 +313,7 @@ def _load_gtinf_records(db_path: Path, model: str, imei: str) -> List[InfoRecord
     conn = ensure_db(db_path)
     _register_sqlite_helpers(conn)
     conn.row_factory = sqlite3.Row
-    table = _detect_table(conn, "gtinf", model)
+    table = _detect_table(conn, "gtinf", model, imei)
     columns = _load_table_schema(conn, table)
 
     imei_col = _first_existing(IMEI_CANDIDATES, columns)
@@ -576,6 +576,7 @@ class FilterPanel(MacroElement):
                 var networkSelect = document.getElementById(panelId + "_network");
                 var markersLayer = L.layerGroup().addTo(mapObj);
                 var routeLayer = L.layerGroup().addTo(mapObj);
+                var lastSelectedDay = null;
 
                 function colorForOperator(operator) {
                     if (operatorColors.hasOwnProperty(operator)) {
@@ -607,37 +608,91 @@ class FilterPanel(MacroElement):
                     return chosen;
                 }
 
+                function collectUnique(points, key) {
+                    var seen = {};
+                    for (var i = 0; i < points.length; i += 1) {
+                        var value = points[i][key];
+                        if (value && !seen.hasOwnProperty(value)) {
+                            seen[value] = true;
+                        }
+                    }
+                    var values = [];
+                    for (var candidate in seen) {
+                        if (seen.hasOwnProperty(candidate)) {
+                            values.push(candidate);
+                        }
+                    }
+                    values.sort();
+                    return values;
+                }
+
+                function populateSelect(selectElement, values, preserveSelection) {
+                    var previousValue = preserveSelection ? selectElement.value : "All";
+                    selectElement.innerHTML = "";
+                    var allOption = document.createElement("option");
+                    allOption.value = "All";
+                    allOption.textContent = "Todos";
+                    selectElement.appendChild(allOption);
+                    for (var i = 0; i < values.length; i += 1) {
+                        var option = document.createElement("option");
+                        option.value = values[i];
+                        option.textContent = values[i];
+                        selectElement.appendChild(option);
+                    }
+                    if (preserveSelection && values.indexOf(previousValue) !== -1) {
+                        selectElement.value = previousValue;
+                    } else {
+                        selectElement.value = "All";
+                    }
+                }
+
+                function pointsForDay(dayValue) {
+                    var dayPoints = [];
+                    for (var i = 0; i < pointsData.length; i += 1) {
+                        var point = pointsData[i];
+                        if (point.day === dayValue) {
+                            dayPoints.push(point);
+                        }
+                    }
+                    return dayPoints;
+                }
+
                 function updateFilters() {
                     var selectedDay = daySelect.value;
                     var dayActive = selectedDay && selectedDay !== "All";
-                    operatorSelect.disabled = !dayActive;
-                    networkSelect.disabled = !dayActive;
+                    var filtered = [];
+                    var basePoints;
+
                     if (!dayActive) {
-                        operatorSelect.value = "All";
-                        networkSelect.value = "All";
+                        operatorSelect.disabled = true;
+                        networkSelect.disabled = true;
+                        populateSelect(operatorSelect, [], false);
+                        populateSelect(networkSelect, [], false);
+                        basePoints = pointsData.slice();
+                        lastSelectedDay = null;
+                    } else {
+                        var dayPoints = pointsForDay(selectedDay);
+                        var preserve = selectedDay === lastSelectedDay;
+                        populateSelect(operatorSelect, collectUnique(dayPoints, "operator"), preserve);
+                        populateSelect(networkSelect, collectUnique(dayPoints, "network"), preserve);
+                        operatorSelect.disabled = false;
+                        networkSelect.disabled = false;
+                        basePoints = dayPoints;
+                        lastSelectedDay = selectedDay;
                     }
 
-                    var filtered = [];
-                    for (var i = 0; i < pointsData.length; i += 1) {
-                        var point = pointsData[i];
-                        if (dayActive && point.day !== selectedDay) {
+                    var opValue = operatorSelect.value || "All";
+                    var netValue = networkSelect.value || "All";
+
+                    for (var i = 0; i < basePoints.length; i += 1) {
+                        var point = basePoints[i];
+                        if (opValue !== "All" && point.operator !== opValue) {
                             continue;
                         }
-                        if (dayActive) {
-                            var opValue = operatorSelect.value || "All";
-                            if (opValue !== "All" && point.operator !== opValue) {
-                                continue;
-                            }
-                            var netValue = networkSelect.value || "All";
-                            if (netValue !== "All" && point.network !== netValue) {
-                                continue;
-                            }
+                        if (netValue !== "All" && point.network !== netValue) {
+                            continue;
                         }
                         filtered.push(point);
-                    }
-
-                    if (!dayActive) {
-                        filtered = pointsData.slice();
                     }
 
                     filtered.sort(function(a, b) {
@@ -779,6 +834,7 @@ def build_points(
                 report=report,
                 model=model_clean,
                 base_dir=base_dir,
+                imei=imei,
             )
         except FileNotFoundError:
             searched_paths.append(db_path)

--- a/viz/utils.py
+++ b/viz/utils.py
@@ -181,8 +181,15 @@ def first_existing(
     return None
 
 
-def detect_table(conn, report: str, model: str) -> str:
-    """Detecta el nombre de tabla apropiado para un reporte/modelo."""
+def detect_table(conn, report: str, model: str, imei: str | None = None) -> str:
+    """Detecta el nombre de tabla apropiado para un reporte/modelo/IMEI.
+
+    Cuando ``imei`` se especifica, se priorizan nombres de tabla que la
+    incluyan para soportar bases con particiones por dispositivo
+    (``gteri_<modelo>_<imei>`` o ``gtinf_<modelo>_<imei>``). Si no se
+    encuentra coincidencia exacta, se mantiene la heurística previa basada en
+    ``reporte`` y ``modelo`` solamente.
+    """
 
     cursor = conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
     names = [row[0] for row in cursor.fetchall()]
@@ -190,7 +197,22 @@ def detect_table(conn, report: str, model: str) -> str:
         raise ValueError("La base de datos no tiene tablas")
     model_lower = model.lower()
     report_lower = report.lower()
-    candidates = [
+    imei_candidates: list[str] = []
+    if imei:
+        imei_text = "".join(ch for ch in str(imei).strip() if ch.isalnum())
+        if imei_text:
+            imei_candidates = [
+                f"{report_lower}_{model_lower}_{imei_text}",
+                f"{report_lower}_{model}_{imei_text}",
+                f"{report}_{model_lower}_{imei_text}",
+                f"{report}_{model}_{imei_text}",
+                f"{model_lower}_{report_lower}_{imei_text}",
+                f"{model}_{report}_{imei_text}",
+                f"{report_lower}_{imei_text}",
+                f"{report}_{imei_text}",
+            ]
+
+    candidates = imei_candidates + [
         f"{report_lower}_{model_lower}",
         f"{report_lower}_{model}",
         f"{report}_{model_lower}",


### PR DESCRIPTION
## Summary
- prioritize IMEI-specific table names when loading gteri/gtinf data and propagate the IMEI to the enrichment workflow
- refresh the interactive map filter panel so operator and technology options follow the selected day while keeping the route colouring by operator

## Testing
- pytest *(fails: baseline parser suite has known failures unrelated to map generation)*
- pytest tests/viz/test_mapa_recorridos.py


------
https://chatgpt.com/codex/tasks/task_e_68f79435cec88333a38aefe6506cc8b2