### PR TITLE
Handle Spanish "Todos" values in interactive map filters

### DIFF
--- a/tests/viz/test_mapa_recorridos.py
+++ b/tests/viz/test_mapa_recorridos.py
@@ -149,7 +149,10 @@ def test_filter_points_accepts_all_keyword_for_every_filter():
 
     assert _filter_points(points, operators=["All"]) == points
     assert _filter_points(points, networks=["ALL"]) == points
+    assert _filter_points(points, operators=["Todos"]) == points
+    assert _filter_points(points, networks=["TODOS"]) == points
     assert _filter_points(points, day="all") == points
+    assert _filter_points(points, day="TODOS") == points
 
 
 def test_filter_points_day_filter_has_priority():

--- a/tests/viz/test_mapa_recorridos.py
+++ b/tests/viz/test_mapa_recorridos.py
@@ -10,6 +10,7 @@ from viz.mapa_recorridos import (
     InfoRecord,
     LocationPoint,
     _associate_info,
+    _build_interactive_payload,
     _filter_points,
     _normalize_operator,
     _safe_int,
@@ -194,6 +195,36 @@ def test_filter_points_returns_empty_when_combination_not_found():
         operators=["Entel"],
         networks=["4G"],
     ) == []
+
+
+def test_build_interactive_payload_groups_summary_by_day():
+    points = [
+        _make_point(0, operator="Claro", network="2G"),
+        _make_point(60, operator="Entel", network="3G"),
+        _make_point(86400, operator="Claro", network="4G"),
+    ]
+
+    (
+        _points_payload,
+        days,
+        operators,
+        networks,
+        day_summary,
+        initial_day,
+    ) = _build_interactive_payload(points)
+
+    assert days == ["2025-10-10", "2025-10-11"]
+    assert operators == ["Claro", "Entel"]
+    assert networks == ["2G", "3G", "4G"]
+    assert day_summary["2025-10-10"] == {
+        "operators": ["Claro", "Entel"],
+        "networks": ["2G", "3G"],
+    }
+    assert day_summary["2025-10-11"] == {
+        "operators": ["Claro"],
+        "networks": ["4G"],
+    }
+    assert initial_day == "2025-10-10"
 
 
 def test_enriched_database_creates_columns_and_values(tmp_path: Path):

--- a/viz/enriched_db.py
+++ b/viz/enriched_db.py
@@ -38,7 +38,7 @@ def _ensure_column(conn: sqlite3.Connection, table: str, column: str, definition
 
 
 def _load_gtinf_lookup(
-    gtinf_path: Path, model: str
+    gtinf_path: Path, model: str, imei: str | None = None
 ) -> Dict[str, List[Tuple[datetime, str, str, Optional[float]]]]:
     if not gtinf_path.exists():
         return {}
@@ -46,7 +46,7 @@ def _load_gtinf_lookup(
     conn = ensure_db(gtinf_path)
     conn.row_factory = sqlite3.Row
     try:
-        table = detect_table(conn, "gtinf", model)
+        table = detect_table(conn, "gtinf", model, imei)
         columns = load_table_schema(conn, table)
         imei_col = first_existing(IMEI_CANDIDATES, columns)
         time_col = first_existing(TIME_CANDIDATES, columns)
@@ -90,7 +90,9 @@ def _resolve_output_path(base_dir: Path, report: str, model: str) -> Path:
     return base_dir / name
 
 
-def ensure_enriched_database(*, report: str, model: str, base_dir: Path | str) -> Path:
+def ensure_enriched_database(
+    *, report: str, model: str, base_dir: Path | str, imei: str | None = None
+) -> Path:
     """Genera (si es necesario) una copia enriquecida de la base de recorridos."""
 
     base_path = Path(base_dir)
@@ -120,7 +122,7 @@ def ensure_enriched_database(*, report: str, model: str, base_dir: Path | str) -
         conn = ensure_db(output_path)
         conn.row_factory = sqlite3.Row
         try:
-            table = detect_table(conn, report_clean, model_clean)
+            table = detect_table(conn, report_clean, model_clean, imei)
             _ensure_column(conn, table, "tecnologia_celular", "TEXT")
             _ensure_column(conn, table, "calidad_senal", "TEXT")
             _ensure_column(conn, table, "nivel_senal_dbm", "REAL")
@@ -138,7 +140,7 @@ def ensure_enriched_database(*, report: str, model: str, base_dir: Path | str) -
             )
             conn.execute(f'UPDATE "{table}" SET "operador" = "Desconocido"')
 
-            gtinf_lookup = _load_gtinf_lookup(gtinf_path, model_clean)
+            gtinf_lookup = _load_gtinf_lookup(gtinf_path, model_clean, imei)
             if not gtinf_lookup:
                 conn.commit()
             else:

--- a/viz/mapa_recorridos.py
+++ b/viz/mapa_recorridos.py
@@ -460,6 +460,64 @@ def _filter_points(
 # Render del mapa ------------------------------------------------------------
 
 
+def _build_interactive_payload(
+    points: List[LocationPoint],
+) -> Tuple[
+    List[dict],
+    List[str],
+    List[str],
+    List[str],
+    Dict[str, Dict[str, List[str]]],
+    str,
+]:
+    """Prepara datos serializables para el panel interactivo."""
+
+    points_sorted = sorted(points, key=lambda p: p.send_time)
+    days = sorted({p.send_time.date().isoformat() for p in points_sorted})
+    operators = sorted({(p.operator or "Desconocido") for p in points_sorted})
+    networks = sorted({(p.network_label or "Desconocida") for p in points_sorted})
+
+    points_payload: List[dict] = []
+    summary: Dict[str, Dict[str, set[str]]] = {}
+    for point in points_sorted:
+        day = point.send_time.date().isoformat()
+        operator = point.operator or "Desconocido"
+        network = point.network_label or "Desconocida"
+        points_payload.append(
+            {
+                "lat": point.lat,
+                "lon": point.lon,
+                "day": day,
+                "operator": operator,
+                "network": network,
+                "tooltip": _point_to_tooltip(point),
+                "timestamp": point.send_time.isoformat(),
+            }
+        )
+
+        bucket = summary.setdefault(day, {"operators": set(), "networks": set()})
+        bucket["operators"].add(operator)
+        bucket["networks"].add(network)
+
+    summary_serializable: Dict[str, Dict[str, List[str]]] = {}
+    for day, values in summary.items():
+        summary_serializable[day] = {
+            "operators": sorted(values["operators"]),
+            "networks": sorted(values["networks"]),
+        }
+
+    initial_day = days[0] if days else "Todos"
+
+    return (
+        points_payload,
+        days,
+        operators,
+        networks,
+        summary_serializable,
+        initial_day,
+    )
+
+
 def _ensure_output_path(path: Path) -> None:
     if not path.parent.exists():
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -526,6 +584,7 @@ class FilterPanel(MacroElement):
         network_options: List[str],
         operator_colors: Dict[str, str],
         initial_day: str,
+        day_summary: Dict[str, Dict[str, List[str]]],
     ) -> None:
         if Template is None:  # pragma: no cover - dependencia opcional
             raise RuntimeError(
@@ -535,6 +594,7 @@ class FilterPanel(MacroElement):
         self._name = "FilterPanel"
         self.points_json = json.dumps(points_data, ensure_ascii=False)
         self.operator_colors_json = json.dumps(operator_colors, ensure_ascii=False)
+        self.day_summary_json = json.dumps(day_summary, ensure_ascii=False)
         self.day_options = day_options
         self.operator_options = operator_options
         self.network_options = network_options
@@ -576,6 +636,7 @@ class FilterPanel(MacroElement):
             (function() {
                 var mapObj = {{ this._parent.get_name() }};
                 var pointsData = {{ this.points_json | safe }};
+                var daySummary = {{ this.day_summary_json | safe }};
                 var operatorColors = {{ this.operator_colors_json | safe }};
                 var panelId = "{{ this.get_name() }}";
                 var daySelect = document.getElementById(panelId + "_day");
@@ -585,6 +646,19 @@ class FilterPanel(MacroElement):
                 var routeLayer = L.layerGroup().addTo(mapObj);
                 var lastSelectedDay = null;
                 var ALL_KEYWORDS = { "todos": true, "todas": true, "all": true };
+
+                var dayIndex = (function() {
+                    var index = {};
+                    for (var i = 0; i < pointsData.length; i += 1) {
+                        var point = pointsData[i];
+                        var key = point.day;
+                        if (!index.hasOwnProperty(key)) {
+                            index[key] = [];
+                        }
+                        index[key].push(point);
+                    }
+                    return index;
+                })();
 
                 function isAllValue(value) {
                     if (value === undefined || value === null) {
@@ -627,24 +701,6 @@ class FilterPanel(MacroElement):
                     return chosen;
                 }
 
-                function collectUnique(points, key) {
-                    var seen = {};
-                    for (var i = 0; i < points.length; i += 1) {
-                        var value = points[i][key];
-                        if (value && !seen.hasOwnProperty(value)) {
-                            seen[value] = true;
-                        }
-                    }
-                    var values = [];
-                    for (var candidate in seen) {
-                        if (seen.hasOwnProperty(candidate)) {
-                            values.push(candidate);
-                        }
-                    }
-                    values.sort();
-                    return values;
-                }
-
                 function populateSelect(selectElement, values, preserveSelection) {
                     var previousValue = preserveSelection ? selectElement.value : "Todos";
                     if (!previousValue || isAllValue(previousValue)) {
@@ -668,21 +724,19 @@ class FilterPanel(MacroElement):
                     }
                 }
 
-                function pointsForDay(dayValue) {
-                    var dayPoints = [];
-                    for (var i = 0; i < pointsData.length; i += 1) {
-                        var point = pointsData[i];
-                        if (point.day === dayValue) {
-                            dayPoints.push(point);
-                        }
-                    }
-                    return dayPoints;
-                }
-
                 function updateFilters() {
                     var selectedDay = daySelect.value;
                     var dayActive = selectedDay && !isAllValue(selectedDay);
-                    var basePoints = dayActive ? pointsForDay(selectedDay) : pointsData.slice();
+                    var basePoints;
+                    if (dayActive) {
+                        if (dayIndex.hasOwnProperty(selectedDay)) {
+                            basePoints = dayIndex[selectedDay].slice();
+                        } else {
+                            basePoints = [];
+                        }
+                    } else {
+                        basePoints = pointsData.slice();
+                    }
                     var filtered = [];
 
                     if (!dayActive) {
@@ -693,10 +747,13 @@ class FilterPanel(MacroElement):
                         lastSelectedDay = null;
                     } else {
                         var preserve = selectedDay === lastSelectedDay;
-                        populateSelect(operatorSelect, collectUnique(basePoints, "operator"), preserve);
-                        populateSelect(networkSelect, collectUnique(basePoints, "network"), preserve);
-                        operatorSelect.disabled = false;
-                        networkSelect.disabled = false;
+                        var summary = daySummary.hasOwnProperty(selectedDay)
+                            ? daySummary[selectedDay]
+                            : { operators: [], networks: [] };
+                        populateSelect(operatorSelect, summary.operators || [], preserve);
+                        populateSelect(networkSelect, summary.networks || [], preserve);
+                        operatorSelect.disabled = (summary.operators || []).length === 0;
+                        networkSelect.disabled = (summary.networks || []).length === 0;
                         lastSelectedDay = selectedDay;
                     }
 
@@ -792,24 +849,14 @@ def render_interactive_map(
     center_lat = points_sorted[0].lat
     center_lon = points_sorted[0].lon
     fmap = Map(location=(center_lat, center_lon), zoom_start=13, tiles=tiles)
-    days = sorted({p.send_time.date().isoformat() for p in points_sorted})
-    operators = sorted({(p.operator or "Desconocido") for p in points_sorted})
-    networks = sorted({(p.network_label or "Desconocida") for p in points_sorted})
-
-    points_payload = [
-        {
-            "lat": point.lat,
-            "lon": point.lon,
-            "day": point.send_time.date().isoformat(),
-            "operator": point.operator or "Desconocido",
-            "network": point.network_label or "Desconocida",
-            "tooltip": _point_to_tooltip(point),
-            "timestamp": point.send_time.isoformat(),
-        }
-        for point in points_sorted
-    ]
-
-    initial_day = days[0] if days else "Todos"
+    (
+        points_payload,
+        days,
+        operators,
+        networks,
+        day_summary,
+        initial_day,
+    ) = _build_interactive_payload(points_sorted)
 
     fmap.get_root().add_child(
         FilterPanel(
@@ -819,6 +866,7 @@ def render_interactive_map(
             network_options=networks,
             operator_colors=OPERATOR_COLORS,
             initial_day=initial_day,
+            day_summary=day_summary,
         )
     )
 

--- a/viz/mapa_recorridos.py
+++ b/viz/mapa_recorridos.py
@@ -190,7 +190,7 @@ def _load_locations_from_db(
     _register_sqlite_helpers(conn)
     conn.row_factory = sqlite3.Row
     try:
-        table = _detect_table(conn, report, model)
+        table = _detect_table(conn, report, model, imei)
         columns = _load_table_schema(conn, table)
 
         imei_col = _first_existing(IMEI_CANDIDATES, columns)
@@ -313,7 +313,7 @@ def _load_gtinf_records(db_path: Path, model: str, imei: str) -> List[InfoRecord
     conn = ensure_db(db_path)
     _register_sqlite_helpers(conn)
     conn.row_factory = sqlite3.Row
-    table = _detect_table(conn, "gtinf", model)
+    table = _detect_table(conn, "gtinf", model, imei)
     columns = _load_table_schema(conn, table)
 
     imei_col = _first_existing(IMEI_CANDIDATES, columns)
@@ -393,6 +393,30 @@ def _associate_info(points: List[LocationPoint], infos: List[InfoRecord]) -> Non
 # Filtros --------------------------------------------------------------------
 
 
+def _is_all_keyword(value: Optional[str]) -> bool:
+    if value in (None, ""):
+        return False
+    normalized = value.strip().lower()
+    return normalized in {"all", "todos", "todas"}
+
+
+def _normalize_filter_values(values: Optional[Sequence[str]]) -> Optional[set[str]]:
+    if not values:
+        return None
+
+    normalized: set[str] = set()
+    for raw in values:
+        if raw in (None, ""):
+            continue
+        text = str(raw).strip()
+        if not text:
+            continue
+        if _is_all_keyword(text):
+            return None
+        normalized.add(text.lower())
+    return normalized or None
+
+
 def _filter_points(
     points: List[LocationPoint],
     day: Optional[str] = None,
@@ -401,21 +425,10 @@ def _filter_points(
 ) -> List[LocationPoint]:
     """Filtra puntos aplicando prioridad al día antes que otros filtros."""
 
-    normalized_ops = (
-        {op.strip().lower() for op in operators if op is not None}
-        if operators
-        else None
-    )
-    normalized_networks = (
-        {nt.strip().lower() for nt in networks if nt is not None}
-        if networks
-        else None
-    )
-
     day_value: Optional[datetime] = None
     if day:
         day_clean = day.strip()
-        if day_clean.lower() != "all":
+        if day_clean and not _is_all_keyword(day_clean):
             try:
                 day_value = datetime.strptime(day_clean, "%Y-%m-%d")
             except ValueError as exc:  # pragma: no cover - validación de CLI
@@ -424,27 +437,21 @@ def _filter_points(
     # Priorizamos la selección por día. Si no se especifica un día, se mantienen todos
     # los puntos disponibles y los filtros complementarios quedan deshabilitados.
     if day_value is None:
-        day_filtered = list(points)
-        operator_set = None
-        network_set = None
-    else:
-        day_filtered = [
-            point for point in points if point.send_time.date() == day_value.date()
-        ]
-        operator_set = (
-            None if not normalized_ops or "all" in normalized_ops else normalized_ops
-        )
-        network_set = (
-            None
-            if not normalized_networks or "all" in normalized_networks
-            else normalized_networks
-        )
+        return list(points)
+
+    operator_set = _normalize_filter_values(operators)
+    network_set = _normalize_filter_values(networks)
 
     result: List[LocationPoint] = []
-    for point in day_filtered:
-        if operator_set and (point.operator or "").lower() not in operator_set:
+    day_date = day_value.date()
+    for point in points:
+        if point.send_time.date() != day_date:
             continue
-        if network_set and (point.network_label or "").lower() not in network_set:
+        operator_value = (point.operator or "").strip().lower()
+        if operator_set and operator_value not in operator_set:
+            continue
+        network_value = (point.network_label or "").strip().lower()
+        if network_set and network_value not in network_set:
             continue
         result.append(point)
     return result
@@ -542,21 +549,21 @@ class FilterPanel(MacroElement):
                     <div style="font-weight: bold; margin-bottom: 8px; font-size: 14px;">Filtros</div>
                     <label for="{{ this.get_name() }}_day" style="display:block; font-weight:bold; margin-bottom:4px;">Día</label>
                     <select id="{{ this.get_name() }}_day" style="width:100%; margin-bottom:10px; padding:4px;">
-                        <option value="All">Todos</option>
+                        <option value="Todos">Todos</option>
                         {% for day in this.day_options %}
                         <option value="{{ day }}" {% if day == this.initial_day %}selected{% endif %}>{{ day }}</option>
                         {% endfor %}
                     </select>
                     <label for="{{ this.get_name() }}_operator" style="display:block; font-weight:bold; margin-bottom:4px;">Operador</label>
                     <select id="{{ this.get_name() }}_operator" style="width:100%; margin-bottom:10px; padding:4px;" disabled>
-                        <option value="All" selected>Todos</option>
+                        <option value="Todos" selected>Todos</option>
                         {% for operator in this.operator_options %}
                         <option value="{{ operator }}">{{ operator }}</option>
                         {% endfor %}
                     </select>
                     <label for="{{ this.get_name() }}_network" style="display:block; font-weight:bold; margin-bottom:4px;">Tecnología</label>
                     <select id="{{ this.get_name() }}_network" style="width:100%; padding:4px;" disabled>
-                        <option value="All" selected>Todos</option>
+                        <option value="Todos" selected>Todos</option>
                         {% for network in this.network_options %}
                         <option value="{{ network }}">{{ network }}</option>
                         {% endfor %}
@@ -576,6 +583,19 @@ class FilterPanel(MacroElement):
                 var networkSelect = document.getElementById(panelId + "_network");
                 var markersLayer = L.layerGroup().addTo(mapObj);
                 var routeLayer = L.layerGroup().addTo(mapObj);
+                var lastSelectedDay = null;
+                var ALL_KEYWORDS = { "todos": true, "todas": true, "all": true };
+
+                function isAllValue(value) {
+                    if (value === undefined || value === null) {
+                        return true;
+                    }
+                    var text = String(value).trim();
+                    if (text === "") {
+                        return true;
+                    }
+                    return ALL_KEYWORDS.hasOwnProperty(text.toLowerCase());
+                }
 
                 function colorForOperator(operator) {
                     if (operatorColors.hasOwnProperty(operator)) {
@@ -607,37 +627,91 @@ class FilterPanel(MacroElement):
                     return chosen;
                 }
 
-                function updateFilters() {
-                    var selectedDay = daySelect.value;
-                    var dayActive = selectedDay && selectedDay !== "All";
-                    operatorSelect.disabled = !dayActive;
-                    networkSelect.disabled = !dayActive;
-                    if (!dayActive) {
-                        operatorSelect.value = "All";
-                        networkSelect.value = "All";
+                function collectUnique(points, key) {
+                    var seen = {};
+                    for (var i = 0; i < points.length; i += 1) {
+                        var value = points[i][key];
+                        if (value && !seen.hasOwnProperty(value)) {
+                            seen[value] = true;
+                        }
                     }
+                    var values = [];
+                    for (var candidate in seen) {
+                        if (seen.hasOwnProperty(candidate)) {
+                            values.push(candidate);
+                        }
+                    }
+                    values.sort();
+                    return values;
+                }
 
-                    var filtered = [];
+                function populateSelect(selectElement, values, preserveSelection) {
+                    var previousValue = preserveSelection ? selectElement.value : "Todos";
+                    if (!previousValue || isAllValue(previousValue)) {
+                        previousValue = "Todos";
+                    }
+                    selectElement.innerHTML = "";
+                    var allOption = document.createElement("option");
+                    allOption.value = "Todos";
+                    allOption.textContent = "Todos";
+                    selectElement.appendChild(allOption);
+                    for (var i = 0; i < values.length; i += 1) {
+                        var option = document.createElement("option");
+                        option.value = values[i];
+                        option.textContent = values[i];
+                        selectElement.appendChild(option);
+                    }
+                    if (preserveSelection && values.indexOf(previousValue) !== -1) {
+                        selectElement.value = previousValue;
+                    } else {
+                        selectElement.value = "Todos";
+                    }
+                }
+
+                function pointsForDay(dayValue) {
+                    var dayPoints = [];
                     for (var i = 0; i < pointsData.length; i += 1) {
                         var point = pointsData[i];
-                        if (dayActive && point.day !== selectedDay) {
-                            continue;
+                        if (point.day === dayValue) {
+                            dayPoints.push(point);
                         }
-                        if (dayActive) {
-                            var opValue = operatorSelect.value || "All";
-                            if (opValue !== "All" && point.operator !== opValue) {
-                                continue;
-                            }
-                            var netValue = networkSelect.value || "All";
-                            if (netValue !== "All" && point.network !== netValue) {
-                                continue;
-                            }
-                        }
-                        filtered.push(point);
                     }
+                    return dayPoints;
+                }
+
+                function updateFilters() {
+                    var selectedDay = daySelect.value;
+                    var dayActive = selectedDay && !isAllValue(selectedDay);
+                    var basePoints = dayActive ? pointsForDay(selectedDay) : pointsData.slice();
+                    var filtered = [];
 
                     if (!dayActive) {
-                        filtered = pointsData.slice();
+                        operatorSelect.disabled = true;
+                        networkSelect.disabled = true;
+                        populateSelect(operatorSelect, [], false);
+                        populateSelect(networkSelect, [], false);
+                        lastSelectedDay = null;
+                    } else {
+                        var preserve = selectedDay === lastSelectedDay;
+                        populateSelect(operatorSelect, collectUnique(basePoints, "operator"), preserve);
+                        populateSelect(networkSelect, collectUnique(basePoints, "network"), preserve);
+                        operatorSelect.disabled = false;
+                        networkSelect.disabled = false;
+                        lastSelectedDay = selectedDay;
+                    }
+
+                    var opValue = operatorSelect.value;
+                    var netValue = networkSelect.value;
+
+                    for (var i = 0; i < basePoints.length; i += 1) {
+                        var point = basePoints[i];
+                        if (dayActive && !isAllValue(opValue) && point.operator !== opValue) {
+                            continue;
+                        }
+                        if (dayActive && !isAllValue(netValue) && point.network !== netValue) {
+                            continue;
+                        }
+                        filtered.push(point);
                     }
 
                     filtered.sort(function(a, b) {
@@ -683,7 +757,7 @@ class FilterPanel(MacroElement):
 
                     if (latLngs.length >= 2) {
                         var routeColor;
-                        if (dayActive && operatorSelect.value && operatorSelect.value !== "All") {
+                        if (dayActive && operatorSelect.value && !isAllValue(operatorSelect.value)) {
                             routeColor = colorForOperator(operatorSelect.value);
                         } else {
                             var dominant = dominantOperator(filtered);
@@ -735,7 +809,7 @@ def render_interactive_map(
         for point in points_sorted
     ]
 
-    initial_day = days[0] if days else "All"
+    initial_day = days[0] if days else "Todos"
 
     fmap.get_root().add_child(
         FilterPanel(
@@ -779,6 +853,7 @@ def build_points(
                 report=report,
                 model=model_clean,
                 base_dir=base_dir,
+                imei=imei,
             )
         except FileNotFoundError:
             searched_paths.append(db_path)

--- a/viz/utils.py
+++ b/viz/utils.py
@@ -181,8 +181,15 @@ def first_existing(
     return None
 
 
-def detect_table(conn, report: str, model: str) -> str:
-    """Detecta el nombre de tabla apropiado para un reporte/modelo."""
+def detect_table(conn, report: str, model: str, imei: str | None = None) -> str:
+    """Detecta el nombre de tabla apropiado para un reporte/modelo/IMEI.
+
+    Cuando ``imei`` se especifica, se priorizan nombres de tabla que la
+    incluyan para soportar bases con particiones por dispositivo
+    (``gteri_<modelo>_<imei>`` o ``gtinf_<modelo>_<imei>``). Si no se
+    encuentra coincidencia exacta, se mantiene la heurística previa basada en
+    ``reporte`` y ``modelo`` solamente.
+    """
 
     cursor = conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
     names = [row[0] for row in cursor.fetchall()]
@@ -190,7 +197,22 @@ def detect_table(conn, report: str, model: str) -> str:
         raise ValueError("La base de datos no tiene tablas")
     model_lower = model.lower()
     report_lower = report.lower()
-    candidates = [
+    imei_candidates: list[str] = []
+    if imei:
+        imei_text = "".join(ch for ch in str(imei).strip() if ch.isalnum())
+        if imei_text:
+            imei_candidates = [
+                f"{report_lower}_{model_lower}_{imei_text}",
+                f"{report_lower}_{model}_{imei_text}",
+                f"{report}_{model_lower}_{imei_text}",
+                f"{report}_{model}_{imei_text}",
+                f"{model_lower}_{report_lower}_{imei_text}",
+                f"{model}_{report}_{imei_text}",
+                f"{report_lower}_{imei_text}",
+                f"{report}_{imei_text}",
+            ]
+
+    candidates = imei_candidates + [
         f"{report_lower}_{model_lower}",
         f"{report_lower}_{model}",
         f"{report}_{model_lower}",


### PR DESCRIPTION
## Summary
- accept Spanish "Todos"/"Todas" tokens as "All" in the server-side map filtering logic
- refresh the interactive map filter panel to use the localized token and to guard its comparisons with a shared helper

## Testing
- pytest tests/viz/test_mapa_recorridos.py

------
https://chatgpt.com/codex/tasks/task_e_68f79435cec88333a38aefe6506cc8b2