### PR TITLE
Corrección completa de filtros y agregado de “Tipo de reporte” en la funcionalidad “Mapas interactivos por IMEI y operador”

### DIFF
--- a/tests/viz/test_mapa_recorridos.py
+++ b/tests/viz/test_mapa_recorridos.py
@@ -444,6 +444,102 @@ def test_build_points_swaps_coordinates_without_mcc(tmp_path: Path):
     assert all(-80.0 < p.lon < -60.0 for p in points)
 
 
+def test_build_points_uses_existing_map_databases(tmp_path: Path):
+    model = "gv350ceu"
+    imei = "123456789012345"
+    base_dir = tmp_path
+
+    gteri_map_path = base_dir / f"gteri_{model}_map.db"
+    conn = sqlite3.connect(gteri_map_path)
+    conn.execute(
+        f"""
+        CREATE TABLE "gteri_{model}" (
+            imei TEXT,
+            send_time TEXT,
+            lat REAL,
+            lon REAL,
+            mcc TEXT,
+            mnc TEXT,
+            report_type TEXT,
+            tecnologia_celular TEXT,
+            calidad_senal TEXT,
+            nivel_senal_dbm REAL,
+            operador TEXT
+        )
+        """
+    )
+    conn.executemany(
+        f'INSERT INTO "gteri_{model}" (imei, send_time, lat, lon, mcc, mnc, report_type, tecnologia_celular, calidad_senal, nivel_senal_dbm, operador) '
+        'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+        [
+            (
+                imei,
+                "202510100000",
+                -33.45,
+                -70.66,
+                "0730",
+                "0002",
+                "+BUFF:GTERI",
+                "4G",
+                "Excelente",
+                18.0,
+                "Movistar",
+            ),
+            (
+                imei,
+                "202510100100",
+                -33.46,
+                -70.65,
+                "0730",
+                "0002",
+                "+RESP:GTERI",
+                "3G",
+                "Buena",
+                -85.0,
+                "Movistar",
+            ),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    gtinf_map_path = base_dir / f"gtinf_{model}_map.db"
+    conn = sqlite3.connect(gtinf_map_path)
+    conn.execute(
+        f"""
+        CREATE TABLE "gtinf_{model}" (
+            imei TEXT,
+            send_time TEXT,
+            network_type INTEGER,
+            csq REAL,
+            csq_ber INTEGER
+        )
+        """
+    )
+    conn.executemany(
+        f'INSERT INTO "gtinf_{model}" (imei, send_time, network_type, csq, csq_ber) '
+        'VALUES (?, ?, ?, ?, ?)',
+        [
+            (imei, "20251009235950", 3, 160, None),
+            (imei, "202510100055", 2, 90, None),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    points = build_points(
+        model=model,
+        imei=imei,
+        base_dir=base_dir,
+        reports=["gteri"],
+    )
+
+    assert len(points) == 2
+    assert {p.report_kind for p in points} == {"BUFFER", "RESP"}
+    assert all(p.operator == "Movistar" for p in points)
+    assert {p.network_label for p in points} == {"4G", "3G"}
+
+
 def test_render_interactive_map_includes_all_filters(tmp_path: Path):
     pytest.importorskip("folium")
     base_dir = _prepare_sample_databases(tmp_path)
@@ -465,3 +561,6 @@ def test_render_interactive_map_includes_all_filters(tmp_path: Path):
     assert "2025-10-10" in html
     assert ">Operador<" in html
     assert ">Tecnología<" in html
+    assert 'id="FilterPanel_operator" style=' in html
+    operator_fragment = html.split('id="FilterPanel_operator"', 1)[1].split('>', 1)[0]
+    assert "disabled" not in operator_fragment

--- a/viz/enriched_db.py
+++ b/viz/enriched_db.py
@@ -85,6 +85,14 @@ def _load_gtinf_lookup(
         conn.close()
 
 
+def _choose_existing_path(base_dir: Path, *names: str) -> Path:
+    for name in names:
+        candidate = base_dir / name
+        if candidate.exists():
+            return candidate
+    return base_dir / names[0]
+
+
 def _resolve_output_path(base_dir: Path, report: str, model: str) -> Path:
     name = f"{report}_{model}_map.db"
     return base_dir / name
@@ -98,115 +106,123 @@ def ensure_enriched_database(
     base_path = Path(base_dir)
     report_clean = report.strip().lower()
     model_clean = model.strip().lower()
-    source_path = base_path / f"{report_clean}_{model_clean}.db"
-    if not source_path.exists():
-        raise FileNotFoundError(source_path)
-
     output_path = _resolve_output_path(base_path, report_clean, model_clean)
-    gtinf_path = base_path / f"gtinf_{model_clean}.db"
+    source_candidates = [
+        output_path,
+        base_path / f"{report_clean}_{model_clean}.db",
+    ]
+    source_path = next((path for path in source_candidates if path.exists()), None)
+    if source_path is None:
+        raise FileNotFoundError(output_path)
 
-    needs_regen = True
-    if output_path.exists():
+    gtinf_path = _choose_existing_path(
+        base_path, f"gtinf_{model_clean}_map.db", f"gtinf_{model_clean}.db"
+    )
+
+    needs_copy = source_path != output_path
+    needs_regen = needs_copy
+    if not needs_regen and output_path.exists():
         src_mtime = source_path.stat().st_mtime
         out_mtime = output_path.stat().st_mtime
         gtinf_mtime = gtinf_path.stat().st_mtime if gtinf_path.exists() else None
-        if out_mtime >= src_mtime and (gtinf_mtime is None or out_mtime >= gtinf_mtime):
-            needs_regen = False
+        if out_mtime < src_mtime or (gtinf_mtime is not None and out_mtime < gtinf_mtime):
+            needs_regen = True
 
+    output_path.parent.mkdir(parents=True, exist_ok=True)
     if needs_regen:
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-        if output_path.exists():
+        if needs_copy and output_path.exists():
             output_path.unlink()
-        shutil.copy2(source_path, output_path)
+        if needs_copy:
+            shutil.copy2(source_path, output_path)
 
-        conn = ensure_db(output_path)
-        conn.row_factory = sqlite3.Row
-        try:
-            table = detect_table(conn, report_clean, model_clean, imei)
-            _ensure_column(conn, table, "tecnologia_celular", "TEXT")
-            _ensure_column(conn, table, "calidad_senal", "TEXT")
-            _ensure_column(conn, table, "nivel_senal_dbm", "REAL")
-            _ensure_column(conn, table, "operador", "TEXT")
+    conn = ensure_db(output_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        table = detect_table(conn, report_clean, model_clean, imei)
+        _ensure_column(conn, table, "tecnologia_celular", "TEXT")
+        _ensure_column(conn, table, "calidad_senal", "TEXT")
+        _ensure_column(conn, table, "nivel_senal_dbm", "REAL")
+        _ensure_column(conn, table, "operador", "TEXT")
 
-            columns = load_table_schema(conn, table)
-            imei_col = first_existing(IMEI_CANDIDATES, columns)
-            time_col = first_existing(TIME_CANDIDATES, columns)
-            if not imei_col or not time_col:
-                return output_path
-            # Aseguramos valores por defecto para evitar residuos de ejecuciones previas.
-            conn.execute(
-                f'UPDATE "{table}" SET "tecnologia_celular" = "Desconocida", '
-                '"calidad_senal" = "Desconocida", "nivel_senal_dbm" = NULL'
-            )
-            conn.execute(f'UPDATE "{table}" SET "operador" = "Desconocido"')
+        columns = load_table_schema(conn, table)
+        imei_col = first_existing(IMEI_CANDIDATES, columns)
+        time_col = first_existing(TIME_CANDIDATES, columns)
+        if not imei_col or not time_col:
+            return output_path
+        # Aseguramos valores por defecto para evitar residuos de ejecuciones previas.
+        conn.execute(
+            f'UPDATE "{table}" SET "tecnologia_celular" = "Desconocida", '
+            '"calidad_senal" = "Desconocida", "nivel_senal_dbm" = NULL'
+        )
+        conn.execute(f'UPDATE "{table}" SET "operador" = "Desconocido"')
 
-            gtinf_lookup = _load_gtinf_lookup(gtinf_path, model_clean, imei)
-            if not gtinf_lookup:
-                conn.commit()
-            else:
-                select_sql = (
-                    f'SELECT ROWID as __rowid__, "{imei_col}" as imei_value, '
-                    f'"{time_col}" as send_value FROM "{table}" ORDER BY "{time_col}"'
-                )
-                updates: List[Tuple[str, str, Optional[float], int]] = []
-                positions: Dict[str, int] = defaultdict(int)
-
-                for row in conn.execute(select_sql):
-                    imei_val = row["imei_value"]
-                    imei = str(imei_val).strip() if imei_val not in (None, "") else None
-                    if not imei:
-                        continue
-                    send_dt = parse_datetime(row["send_value"])
-                    if send_dt is None:
-                        continue
-                    infos = gtinf_lookup.get(imei)
-                    if not infos:
-                        continue
-                    idx = positions.get(imei, 0)
-                    while idx < len(infos) and infos[idx][0] <= send_dt:
-                        idx += 1
-                    positions[imei] = idx
-                    if idx == 0:
-                        continue
-                    latest = infos[idx - 1]
-                    network_label = latest[1]
-                    signal_quality = latest[2]
-                    signal_dbm = latest[3]
-                    updates.append((network_label, signal_quality, signal_dbm, row["__rowid__"]))
-
-                if updates:
-                    conn.executemany(
-                        f'UPDATE "{table}" SET "tecnologia_celular" = ?, '
-                        f'"calidad_senal" = ?, "nivel_senal_dbm" = ? WHERE ROWID = ?',
-                        updates,
-                    )
-
-            # Actualizamos el operador utilizando MCC/MNC
-            columns = load_table_schema(conn, table)
-            mcc_col = first_existing(MCC_CANDIDATES, columns)
-            mnc_col = first_existing(MNC_CANDIDATES, columns)
-            if mnc_col:
-                select_sql = (
-                    f'SELECT ROWID as __rowid__, '
-                    f'"{mcc_col}" as mcc_value, "{mnc_col}" as mnc_value '
-                    f'FROM "{table}"'
-                )
-                operator_updates: List[Tuple[str, int]] = []
-                for row in conn.execute(select_sql):
-                    mcc = safe_int(row["mcc_value"]) if mcc_col else None
-                    mnc = safe_int(row["mnc_value"])
-                    operator = normalize_operator(mcc, mnc)
-                    operator_updates.append((operator, row["__rowid__"]))
-                if operator_updates:
-                    conn.executemany(
-                        f'UPDATE "{table}" SET "operador" = ? WHERE ROWID = ?',
-                        operator_updates,
-                    )
+        gtinf_lookup = _load_gtinf_lookup(gtinf_path, model_clean, imei)
+        if not gtinf_lookup:
             conn.commit()
-        finally:
-            conn.close()
+        else:
+            select_sql = (
+                f'SELECT ROWID as __rowid__, "{imei_col}" as imei_value, '
+                f'"{time_col}" as send_value FROM "{table}" ORDER BY "{time_col}"'
+            )
+            updates: List[Tuple[str, str, Optional[float], int]] = []
+            positions: Dict[str, int] = defaultdict(int)
+
+            for row in conn.execute(select_sql):
+                imei_val = row["imei_value"]
+                imei_value = str(imei_val).strip() if imei_val not in (None, "") else None
+                if not imei_value:
+                    continue
+                send_dt = parse_datetime(row["send_value"])
+                if send_dt is None:
+                    continue
+                infos = gtinf_lookup.get(imei_value)
+                if not infos:
+                    continue
+                idx = positions.get(imei_value, 0)
+                while idx < len(infos) and infos[idx][0] <= send_dt:
+                    idx += 1
+                positions[imei_value] = idx
+                if idx == 0:
+                    continue
+                latest = infos[idx - 1]
+                network_label = latest[1]
+                signal_quality = latest[2]
+                signal_dbm = latest[3]
+                updates.append((network_label, signal_quality, signal_dbm, row["__rowid__"]))
+
+            if updates:
+                conn.executemany(
+                    f'UPDATE "{table}" SET "tecnologia_celular" = ?, '
+                    f'"calidad_senal" = ?, "nivel_senal_dbm" = ? WHERE ROWID = ?',
+                    updates,
+                )
+
+        columns = load_table_schema(conn, table)
+        mcc_col = first_existing(MCC_CANDIDATES, columns)
+        mnc_col = first_existing(MNC_CANDIDATES, columns)
+        if mnc_col:
+            select_sql = (
+                f'SELECT ROWID as __rowid__, '
+                f'"{mcc_col}" as mcc_value, "{mnc_col}" as mnc_value '
+                f'FROM "{table}"'
+            )
+            operator_updates: List[Tuple[str, int]] = []
+            for row in conn.execute(select_sql):
+                mcc = safe_int(row["mcc_value"]) if mcc_col else None
+                mnc = safe_int(row["mnc_value"])
+                operator = normalize_operator(mcc, mnc)
+                operator_updates.append((operator, row["__rowid__"]))
+            if operator_updates:
+                conn.executemany(
+                    f'UPDATE "{table}" SET "operador" = ? WHERE ROWID = ?',
+                    operator_updates,
+                )
+        conn.commit()
+    finally:
+        conn.close()
 
     return output_path
+
 
 
 __all__ = ["ensure_enriched_database"]

--- a/viz/mapa_recorridos.py
+++ b/viz/mapa_recorridos.py
@@ -637,14 +637,14 @@ class FilterPanel(MacroElement):
                         {% endfor %}
                     </select>
                     <label for="{{ this.get_name() }}_operator" style="display:block; font-weight:bold; margin-bottom:4px;">Operador</label>
-                    <select id="{{ this.get_name() }}_operator" style="width:100%; margin-bottom:10px; padding:4px;" disabled>
+                    <select id="{{ this.get_name() }}_operator" style="width:100%; margin-bottom:10px; padding:4px;">
                         <option value="All" selected>Todos</option>
                         {% for operator in this.operator_options %}
                         <option value="{{ operator }}">{{ operator }}</option>
                         {% endfor %}
                     </select>
                     <label for="{{ this.get_name() }}_network" style="display:block; font-weight:bold; margin-bottom:4px;">Tecnología</label>
-                    <select id="{{ this.get_name() }}_network" style="width:100%; padding:4px;" disabled>
+                    <select id="{{ this.get_name() }}_network" style="width:100%; padding:4px;">
                         <option value="All" selected>Todos</option>
                         {% for network in this.network_options %}
                         <option value="{{ network }}">{{ network }}</option>
@@ -808,7 +808,6 @@ class FilterPanel(MacroElement):
                     var reportChanged = dayChanged || normalizedReport !== lastSelections.report;
 
                     var reportFiltered = filterByReport(basePoints, selectedReport);
-                    reportSelect.disabled = basePoints.length === 0;
 
                     populateSelect(
                         operatorSelect,
@@ -823,8 +822,6 @@ class FilterPanel(MacroElement):
                         []
                     );
 
-                    operatorSelect.disabled = reportFiltered.length === 0;
-                    networkSelect.disabled = reportFiltered.length === 0;
 
                     var opValue = operatorSelect.value || "All";
                     var netValue = networkSelect.value || "All";
@@ -983,11 +980,15 @@ def build_points(
     if not model_clean:
         raise ValueError("El modelo no puede estar vacío")
 
-    reports_to_use = [r.lower() for r in (reports or ["gteri", "gtfri"])]
+    reports_to_use = [r.lower() for r in (reports or ["gteri"])]
     all_points: List[LocationPoint] = []
     searched_paths: List[Path] = []
     for report in reports_to_use:
-        db_path = base_dir / f"{report}_{model_clean}.db"
+        candidate_paths = [
+            base_dir / f"{report}_{model_clean}_map.db",
+            base_dir / f"{report}_{model_clean}.db",
+        ]
+        db_path = next((path for path in candidate_paths if path.exists()), candidate_paths[0])
         try:
             enriched_path = ensure_enriched_database(
                 report=report,
@@ -996,7 +997,7 @@ def build_points(
                 imei=imei,
             )
         except FileNotFoundError:
-            searched_paths.append(db_path)
+            searched_paths.extend(candidate_paths)
             continue
 
         searched_paths.append(enriched_path)
@@ -1004,7 +1005,7 @@ def build_points(
         all_points.extend(points)
 
     if not all_points:
-        existing_paths = [path for path in searched_paths if path.exists()]
+        existing_paths = list({path: None for path in searched_paths if path.exists()}.keys())
         if existing_paths:
             bases_detalle = ", ".join(path.name for path in existing_paths)
             raise FileNotFoundError(
@@ -1012,13 +1013,18 @@ def build_points(
                 f"{imei} en las bases consultadas ({bases_detalle})."
             )
 
-        bases_detalle = ", ".join(path.name for path in searched_paths) or "(ninguna)"
+        all_candidates = list({path: None for path in searched_paths}.keys())
+        bases_detalle = ", ".join(path.name for path in all_candidates) or "(ninguna)"
         raise FileNotFoundError(
             "No se encontraron bases de datos de recorrido para el modelo "
             f"'{model_clean}'. Se buscaron: {bases_detalle}."
         )
 
-    info_path = base_dir / f"gtinf_{model_clean}.db"
+    info_candidates = [
+        base_dir / f"gtinf_{model_clean}_map.db",
+        base_dir / f"gtinf_{model_clean}.db",
+    ]
+    info_path = next((path for path in info_candidates if path.exists()), info_candidates[0])
     info_records = _load_gtinf_records(info_path, model_clean, imei)
     if info_records:
         _associate_info(all_points, info_records)
@@ -1030,7 +1036,7 @@ def generate_map(
     *,
     model: str,
     imei: str,
-    base_dir: Path | str = Path("."),
+    base_dir: Path | str = Path("bases_sqlite"),
     output_dir: Path | str = Path("."),
     day: Optional[str] = None,
     report_types: Optional[Sequence[str]] = None,
@@ -1064,14 +1070,14 @@ def generate_map(
 
 def _parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Genera un mapa interactivo por IMEI utilizando las bases gteri/gtfri/gtinf",
+        description="Genera un mapa interactivo por IMEI utilizando las bases gteri_map y gtinf_map",
     )
     parser.add_argument("--model", required=True, help="Modelo del equipo (ej. gv350ceu)")
     parser.add_argument("--imei", required=True, help="IMEI a consultar")
     parser.add_argument(
         "--db-dir",
-        default=".",
-        help="Directorio que contiene los archivos SQLite (por defecto el directorio actual)",
+        default="bases_sqlite",
+        help="Directorio que contiene los archivos SQLite (por defecto bases_sqlite)",
     )
     parser.add_argument(
         "--out-dir",
@@ -1098,8 +1104,8 @@ def _parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
         "--report",
         dest="reports",
         action="append",
-        choices=["gteri", "gtfri"],
-        help="Limita los reportes de posición a usar (por defecto gteri y gtfri)",
+        choices=["gteri"],
+        help="Limita los reportes de posición a usar (solo se admite gteri)",
     )
     parser.add_argument(
         "--tiles",


### PR DESCRIPTION
## Summary
- ensure the enrichment workflow prefers existing gteri_map/gtinf_map databases and always refreshes operator/technology data
- keep interactive map filters enabled while populating operator and technology options from the current day/report selection
- add regression coverage for map databases and verify the filter panel markup stays active

## Testing
- pytest tests/viz -q

------
https://chatgpt.com/codex/tasks/task_e_68f7a6b40da4833395713a27198e3a5a