### PR TITLE
Improve GTINF enrichment and report filter behaviour

### DIFF
--- a/tests/viz/test_mapa_recorridos.py
+++ b/tests/viz/test_mapa_recorridos.py
@@ -51,7 +51,14 @@ def _make_point(offset_seconds: int, *, operator: str = "Entel", network: str = 
     )
 
 
-def _make_info(offset_seconds: int, *, label: str, csq: float, csq_ber: int | None = None) -> InfoRecord:
+def _make_info(
+    offset_seconds: int,
+    *,
+    label: str,
+    csq: float,
+    csq_ber: int | None = None,
+    operator: str = "Desconocido",
+) -> InfoRecord:
     base = datetime(2025, 10, 10, 0, 0, 0)
     return InfoRecord(
         imei="123456789012345",
@@ -60,6 +67,7 @@ def _make_info(offset_seconds: int, *, label: str, csq: float, csq_ber: int | No
         raw_network_value=None,
         csq=csq,
         csq_ber=csq_ber,
+        operator=operator,
     )
 
 
@@ -78,9 +86,9 @@ def _prepare_sample_databases(tmp_path: Path) -> Path:
         f'INSERT INTO "gteri_{model}" (imei, send_time, lat, lon, mcc, mnc) '
         'VALUES (?, ?, ?, ?, ?, ?)',
         [
-            (imei, "202510100000", -33.45, -70.66, "0730", "0002"),
-            (imei, "202510100020", -33.46, -70.65, "0730", "0002"),
-            (imei, "202510100120", -33.47, -70.64, "0730", "0002"),
+            (imei, "20251010000000", -33.45, -70.66, "0730", "0002"),
+            (imei, "20251010000040", -33.46, -70.65, "0730", "0002"),
+            (imei, "20251010010130", -33.47, -70.64, "0730", "0002"),
         ],
     )
     conn.commit()
@@ -97,7 +105,7 @@ def _prepare_sample_databases(tmp_path: Path) -> Path:
         'VALUES (?, ?, ?, ?, ?)',
         [
             (imei, "202510100000", 3, 160, None),
-            (imei, "202510100100", 1, 12, None),
+            (imei, "202510100120", 1, 12, None),
         ],
     )
     conn.commit()
@@ -126,18 +134,18 @@ def test_associate_info_uses_latest_previous_record():
 
     _associate_info(points, infos)
 
-    assert [point.network_label for point in points] == ["3G", "3G", "3G", "4G"]
+    assert [point.network_label for point in points] == ["3G", "3G", "4G", "4G"]
     assert [point.signal_quality for point in points] == [
         "Buena",
         "Buena",
-        "Buena",
+        "Excelente",
         "Excelente",
     ]
 
 
-def test_associate_info_leaves_points_without_prior_info():
-    points = [_make_point(-30), _make_point(10)]
-    infos = [_make_info(20, label="2G", csq=25)]
+def test_associate_info_ignores_info_farther_than_one_minute():
+    points = [_make_point(0), _make_point(10)]
+    infos = [_make_info(200, label="2G", csq=25)]
 
     _associate_info(points, infos)
 
@@ -145,6 +153,15 @@ def test_associate_info_leaves_points_without_prior_info():
     assert points[0].signal_quality == "Desconocida"
     assert points[1].network_label == "Desconocida"
     assert points[1].signal_quality == "Desconocida"
+
+
+def test_associate_info_updates_operator_when_available():
+    points = [_make_point(0, operator="Desconocido")]
+    infos = [_make_info(0, label="3G", csq=15, operator="Claro")]
+
+    _associate_info(points, infos)
+
+    assert points[0].operator == "Claro"
 
 
 def test_filter_points_accepts_all_keyword_for_every_filter():
@@ -307,7 +324,7 @@ def test_build_points_accepts_whitespace_imei(tmp_path: Path):
     conn.execute(
         f'INSERT INTO "gtinf_{model}" (imei, send_time, network_type, csq, csq_ber) '
         'VALUES (?, ?, ?, ?, ?)',
-        (f"\t{imei}   ", "202401020200", 3, 160, None),
+        (f"\t{imei}   ", "202401020304", 3, 160, None),
     )
     conn.commit()
     conn.close()
@@ -474,7 +491,7 @@ def test_build_points_uses_existing_map_databases(tmp_path: Path):
         [
             (
                 imei,
-                "202510100000",
+                "20251010000000",
                 -33.45,
                 -70.66,
                 "0730",
@@ -487,7 +504,7 @@ def test_build_points_uses_existing_map_databases(tmp_path: Path):
             ),
             (
                 imei,
-                "202510100100",
+                "20251010010130",
                 -33.46,
                 -70.65,
                 "0730",
@@ -520,8 +537,8 @@ def test_build_points_uses_existing_map_databases(tmp_path: Path):
         f'INSERT INTO "gtinf_{model}" (imei, send_time, network_type, csq, csq_ber) '
         'VALUES (?, ?, ?, ?, ?)',
         [
-            (imei, "20251009235950", 3, 160, None),
-            (imei, "202510100055", 2, 90, None),
+            (imei, "20251010000000", 3, 160, None),
+            (imei, "20251010010130", 2, 90, None),
         ],
     )
     conn.commit()
@@ -564,3 +581,8 @@ def test_render_interactive_map_includes_all_filters(tmp_path: Path):
     assert 'id="FilterPanel_operator" style=' in html
     operator_fragment = html.split('id="FilterPanel_operator"', 1)[1].split('>', 1)[0]
     assert "disabled" not in operator_fragment
+    report_fragment = html.split('id="FilterPanel_report"', 1)[1].split('</select>', 1)[0]
+    assert 'value="AMBOS"' in report_fragment
+    assert 'value="BUFFER"' in report_fragment
+    assert 'value="RESP"' in report_fragment
+    assert 'value="All"' not in report_fragment

--- a/viz/enriched_db.py
+++ b/viz/enriched_db.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 
 import shutil
 import sqlite3
+from bisect import bisect_left
 from collections import defaultdict
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Sequence, Tuple
 
 from src.ingestors.sqlite_records import ensure_db
 
@@ -18,6 +20,7 @@ from .utils import (
     MNC_CANDIDATES,
     NETWORK_TYPE_CANDIDATES,
     NETWORK_TYPE_MAP,
+    OPERATOR_CANDIDATES,
     TIME_CANDIDATES,
     classify_signal,
     detect_table,
@@ -30,6 +33,46 @@ from .utils import (
 )
 
 
+_MAX_TIME_DIFF_SECONDS = 60
+
+
+@dataclass(frozen=True)
+class _GTINFEntry:
+    send_time: datetime
+    network_label: str
+    signal_quality: str
+    signal_dbm: Optional[float]
+    operator: str
+
+
+def _best_entry(
+    entries: Sequence[_GTINFEntry],
+    times: Sequence[datetime],
+    target: datetime,
+) -> Optional[_GTINFEntry]:
+    if not entries:
+        return None
+    index = bisect_left(times, target)
+    candidates: List[_GTINFEntry] = []
+    if 0 <= index < len(entries):
+        candidates.append(entries[index])
+    if index > 0:
+        candidates.append(entries[index - 1])
+    best: Optional[_GTINFEntry] = None
+    best_delta: float = float("inf")
+    for candidate in candidates:
+        delta = abs((candidate.send_time - target).total_seconds())
+        if delta > _MAX_TIME_DIFF_SECONDS:
+            continue
+        if best is None or delta < best_delta:
+            best = candidate
+            best_delta = delta
+        elif delta == best_delta:
+            if best.send_time > target >= candidate.send_time:
+                best = candidate
+    return best
+
+
 def _ensure_column(conn: sqlite3.Connection, table: str, column: str, definition: str) -> None:
     info = conn.execute(f'PRAGMA table_info("{table}")').fetchall()
     existing = {row[1] for row in info}
@@ -39,7 +82,7 @@ def _ensure_column(conn: sqlite3.Connection, table: str, column: str, definition
 
 def _load_gtinf_lookup(
     gtinf_path: Path, model: str, imei: str | None = None
-) -> Dict[str, List[Tuple[datetime, str, str, Optional[float]]]]:
+) -> Dict[str, List[_GTINFEntry]]:
     if not gtinf_path.exists():
         return {}
 
@@ -56,20 +99,30 @@ def _load_gtinf_lookup(
 
         csq_col = first_existing(CSQ_CANDIDATES, columns)
         ber_col = first_existing(CSQ_BER_CANDIDATES, columns)
+        operator_col = first_existing(OPERATOR_CANDIDATES, columns)
+        mcc_col = first_existing(MCC_CANDIDATES, columns)
+        mnc_col = first_existing(MNC_CANDIDATES, columns)
 
         query_cols = {imei_col, time_col, network_col}
         if csq_col:
             query_cols.add(csq_col)
         if ber_col:
             query_cols.add(ber_col)
+        if operator_col:
+            query_cols.add(operator_col)
+        if mcc_col:
+            query_cols.add(mcc_col)
+        if mnc_col:
+            query_cols.add(mnc_col)
+
         select_clause = ", ".join(f'"{col}"' for col in query_cols)
         sql = f'SELECT {select_clause} FROM "{table}" ORDER BY "{time_col}"'
 
-        lookup: Dict[str, List[Tuple[datetime, str, str, Optional[float]]]] = defaultdict(list)
+        lookup: Dict[str, List[_GTINFEntry]] = defaultdict(list)
         for row in conn.execute(sql):
             imei_raw = row[imei_col]
-            imei = str(imei_raw).strip() if imei_raw not in (None, "") else None
-            if not imei:
+            imei_value = str(imei_raw).strip() if imei_raw not in (None, "") else None
+            if not imei_value:
                 continue
             send_dt = parse_datetime(row[time_col])
             if send_dt is None:
@@ -79,8 +132,26 @@ def _load_gtinf_lookup(
             csq = safe_float(row[csq_col]) if csq_col else None
             csq_ber = safe_int(row[ber_col]) if ber_col else None
             quality, dbm = classify_signal(network_label, csq, csq_ber)
-            lookup[imei].append((send_dt, network_label, quality, dbm))
-        return {key: sorted(values, key=lambda item: item[0]) for key, values in lookup.items()}
+            operator_value = "Desconocido"
+            if operator_col:
+                raw_operator = row[operator_col]
+                if raw_operator not in (None, ""):
+                    operator_value = str(raw_operator).strip() or "Desconocido"
+            if operator_value in ("", "Desconocido"):
+                mcc_value = safe_int(row[mcc_col]) if mcc_col else None
+                mnc_value = safe_int(row[mnc_col]) if mnc_col else None
+                normalized = normalize_operator(mcc_value, mnc_value)
+                if normalized != "Desconocido" or operator_value == "":
+                    operator_value = normalized
+            entry = _GTINFEntry(
+                send_time=send_dt,
+                network_label=network_label,
+                signal_quality=quality,
+                signal_dbm=dbm,
+                operator=operator_value or "Desconocido",
+            )
+            lookup[imei_value].append(entry)
+        return {key: sorted(values, key=lambda item: item.send_time) for key, values in lookup.items()}
     finally:
         conn.close()
 
@@ -157,15 +228,17 @@ def ensure_enriched_database(
         conn.execute(f'UPDATE "{table}" SET "operador" = "Desconocido"')
 
         gtinf_lookup = _load_gtinf_lookup(gtinf_path, model_clean, imei)
-        if not gtinf_lookup:
-            conn.commit()
-        else:
+        if gtinf_lookup:
             select_sql = (
                 f'SELECT ROWID as __rowid__, "{imei_col}" as imei_value, '
                 f'"{time_col}" as send_value FROM "{table}" ORDER BY "{time_col}"'
             )
+            time_lookup: Dict[str, List[datetime]] = {
+                key: [entry.send_time for entry in entries]
+                for key, entries in gtinf_lookup.items()
+            }
             updates: List[Tuple[str, str, Optional[float], int]] = []
-            positions: Dict[str, int] = defaultdict(int)
+            operator_updates: List[Tuple[str, int]] = []
 
             for row in conn.execute(select_sql):
                 imei_val = row["imei_value"]
@@ -175,26 +248,35 @@ def ensure_enriched_database(
                 send_dt = parse_datetime(row["send_value"])
                 if send_dt is None:
                     continue
-                infos = gtinf_lookup.get(imei_value)
-                if not infos:
+                entries = gtinf_lookup.get(imei_value)
+                times = time_lookup.get(imei_value)
+                if not entries or not times:
                     continue
-                idx = positions.get(imei_value, 0)
-                while idx < len(infos) and infos[idx][0] <= send_dt:
-                    idx += 1
-                positions[imei_value] = idx
-                if idx == 0:
+                chosen = _best_entry(entries, times, send_dt)
+                if chosen is None:
                     continue
-                latest = infos[idx - 1]
-                network_label = latest[1]
-                signal_quality = latest[2]
-                signal_dbm = latest[3]
-                updates.append((network_label, signal_quality, signal_dbm, row["__rowid__"]))
+                updates.append(
+                    (
+                        chosen.network_label,
+                        chosen.signal_quality,
+                        chosen.signal_dbm,
+                        row["__rowid__"],
+                    )
+                )
+                if chosen.operator and chosen.operator not in {"", "Desconocido"}:
+                    operator_updates.append((chosen.operator, row["__rowid__"]))
 
             if updates:
                 conn.executemany(
                     f'UPDATE "{table}" SET "tecnologia_celular" = ?, '
                     f'"calidad_senal" = ?, "nivel_senal_dbm" = ? WHERE ROWID = ?',
                     updates,
+                )
+            if operator_updates:
+                conn.executemany(
+                    f'UPDATE "{table}" SET "operador" = ? '
+                    "WHERE ROWID = ? AND (\"operador\" IS NULL OR TRIM(\"operador\") = '' OR \"operador\" = 'Desconocido')",
+                    operator_updates,
                 )
 
         columns = load_table_schema(conn, table)
@@ -206,16 +288,19 @@ def ensure_enriched_database(
                 f'"{mcc_col}" as mcc_value, "{mnc_col}" as mnc_value '
                 f'FROM "{table}"'
             )
-            operator_updates: List[Tuple[str, int]] = []
+            fallback_updates: List[Tuple[str, int]] = []
             for row in conn.execute(select_sql):
                 mcc = safe_int(row["mcc_value"]) if mcc_col else None
                 mnc = safe_int(row["mnc_value"])
                 operator = normalize_operator(mcc, mnc)
-                operator_updates.append((operator, row["__rowid__"]))
-            if operator_updates:
+                if operator in ("", "Desconocido"):
+                    continue
+                fallback_updates.append((operator, row["__rowid__"]))
+            if fallback_updates:
                 conn.executemany(
-                    f'UPDATE "{table}" SET "operador" = ? WHERE ROWID = ?',
-                    operator_updates,
+                    f'UPDATE "{table}" SET "operador" = ? '
+                    "WHERE ROWID = ? AND (\"operador\" IS NULL OR TRIM(\"operador\") = '' OR \"operador\" = 'Desconocido')",
+                    fallback_updates,
                 )
         conn.commit()
     finally:

--- a/viz/mapa_recorridos.py
+++ b/viz/mapa_recorridos.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import argparse
 import json
 import sqlite3
+from bisect import bisect_left
 from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal, InvalidOperation
@@ -52,6 +53,7 @@ from .utils import (
     MNC_CANDIDATES,
     NETWORK_TYPE_CANDIDATES,
     NETWORK_TYPE_MAP,
+    OPERATOR_CANDIDATES,
     TIME_CANDIDATES,
     classify_signal as _classify_signal,
     detect_table as _detect_table,
@@ -93,6 +95,7 @@ class InfoRecord:
     raw_network_value: Optional[int]
     csq: Optional[float] = None
     csq_ber: Optional[int] = None
+    operator: str = "Desconocido"
 
 NETWORK_COLORS = {
     "2G": "#1f77b4",
@@ -109,6 +112,8 @@ OPERATOR_COLORS = {
     "WOM": "#9467bd",
     "Desconocido": "#7f7f7f",
 }
+
+_ASSOCIATION_MAX_DELTA_SECONDS = 60
 
 # Tipos de reporte -----------------------------------------------------------
 
@@ -394,12 +399,21 @@ def _load_gtinf_records(db_path: Path, model: str, imei: str) -> List[InfoRecord
 
     csq_col = _first_existing(CSQ_CANDIDATES, columns)
     ber_col = _first_existing(CSQ_BER_CANDIDATES, columns)
+    operator_col = _first_existing(OPERATOR_CANDIDATES, columns)
+    mcc_col = _first_existing(MCC_CANDIDATES, columns)
+    mnc_col = _first_existing(MNC_CANDIDATES, columns)
 
     query_cols = {imei_col, time_col, network_col}
     if csq_col:
         query_cols.add(csq_col)
     if ber_col:
         query_cols.add(ber_col)
+    if operator_col:
+        query_cols.add(operator_col)
+    if mcc_col:
+        query_cols.add(mcc_col)
+    if mnc_col:
+        query_cols.add(mnc_col)
 
     imei_expr = _normalized_imei_expression(imei_col)
     select_clause = ", ".join(f'"{col}"' for col in query_cols)
@@ -418,6 +432,17 @@ def _load_gtinf_records(db_path: Path, model: str, imei: str) -> List[InfoRecord
         network_label = NETWORK_TYPE_MAP.get(raw_network, "Desconocida")
         csq = _safe_float(row[csq_col]) if csq_col else None
         csq_ber = _safe_int(row[ber_col]) if ber_col else None
+        operator_value = "Desconocido"
+        if operator_col:
+            raw_operator = row[operator_col]
+            if raw_operator not in (None, ""):
+                operator_value = str(raw_operator).strip() or "Desconocido"
+        if operator_value in ("", "Desconocido"):
+            mcc_value = _safe_int(row[mcc_col]) if mcc_col else None
+            mnc_value = _safe_int(row[mnc_col]) if mnc_col else None
+            normalized = _normalize_operator(mcc_value, mnc_value)
+            if normalized != "Desconocido" or operator_value == "":
+                operator_value = normalized
         info_records.append(
             InfoRecord(
                 imei=imei,
@@ -426,6 +451,7 @@ def _load_gtinf_records(db_path: Path, model: str, imei: str) -> List[InfoRecord
                 raw_network_value=raw_network,
                 csq=csq,
                 csq_ber=csq_ber,
+                operator=operator_value or "Desconocido",
             )
         )
     conn.close()
@@ -439,25 +465,41 @@ def _associate_info(points: List[LocationPoint], infos: List[InfoRecord]) -> Non
     if not points or not infos:
         return
     infos_sorted = sorted(infos, key=lambda r: r.send_time)
-    idx = 0
-    current_info: Optional[InfoRecord] = None
+    info_times = [record.send_time for record in infos_sorted]
     for point in sorted(points, key=lambda p: p.send_time):
-        while idx < len(infos_sorted) and infos_sorted[idx].send_time <= point.send_time:
-            current_info = infos_sorted[idx]
-            idx += 1
-        if current_info is None:
-            continue
-        if point.network_label not in (None, "", "Desconocida"):
-            if point.signal_quality not in (None, "", "Desconocida") and point.signal_dbm is not None:
+        index = bisect_left(info_times, point.send_time)
+        candidates: List[InfoRecord] = []
+        if 0 <= index < len(infos_sorted):
+            candidates.append(infos_sorted[index])
+        if index > 0:
+            candidates.append(infos_sorted[index - 1])
+
+        chosen: Optional[InfoRecord] = None
+        best_delta = float("inf")
+        for candidate in candidates:
+            delta = abs((candidate.send_time - point.send_time).total_seconds())
+            if delta > _ASSOCIATION_MAX_DELTA_SECONDS:
                 continue
-        point.network_label = current_info.network_label
-        point.csq = current_info.csq
-        point.csq_ber = current_info.csq_ber
+            if chosen is None or delta < best_delta:
+                chosen = candidate
+                best_delta = delta
+            elif delta == best_delta:
+                if chosen.send_time > point.send_time >= candidate.send_time:
+                    chosen = candidate
+
+        if chosen is None:
+            continue
+
+        point.network_label = chosen.network_label
+        point.csq = chosen.csq
+        point.csq_ber = chosen.csq_ber
         quality, dbm = _classify_signal(
-            current_info.network_label, current_info.csq, current_info.csq_ber
+            chosen.network_label, chosen.csq, chosen.csq_ber
         )
         point.signal_quality = quality
         point.signal_dbm = dbm
+        if chosen.operator and chosen.operator not in {"", "Desconocido"}:
+            point.operator = chosen.operator
 
 
 # Filtros --------------------------------------------------------------------
@@ -630,11 +672,9 @@ class FilterPanel(MacroElement):
                     </select>
                     <label for="{{ this.get_name() }}_report" style="display:block; font-weight:bold; margin-bottom:4px;">Tipo de reporte</label>
                     <select id="{{ this.get_name() }}_report" style="width:100%; margin-bottom:10px; padding:4px;">
-                        <option value="All" selected>Todos</option>
-                        <option value="AMBOS">Ambos</option>
-                        {% for report in this.report_options %}
-                        <option value="{{ report }}">{{ report }}</option>
-                        {% endfor %}
+                        <option value="AMBOS" selected>AMBOS</option>
+                        <option value="BUFFER">BUFFER</option>
+                        <option value="RESP">RESP</option>
                     </select>
                     <label for="{{ this.get_name() }}_operator" style="display:block; font-weight:bold; margin-bottom:4px;">Operador</label>
                     <select id="{{ this.get_name() }}_operator" style="width:100%; margin-bottom:10px; padding:4px;">
@@ -757,6 +797,32 @@ class FilterPanel(MacroElement):
                     }
                 }
 
+                function populateReportSelect(points, preserveSelection) {
+                    var availableValues = collectUnique(points, "report");
+                    var availableSet = {};
+                    for (var idx = 0; idx < availableValues.length; idx += 1) {
+                        availableSet[availableValues[idx]] = true;
+                    }
+                    var previousValue = preserveSelection ? reportSelect.value : "AMBOS";
+                    if (previousValue !== "BUFFER" && previousValue !== "RESP") {
+                        previousValue = "AMBOS";
+                    } else if (!availableSet[previousValue]) {
+                        previousValue = "AMBOS";
+                    }
+                    var order = ["AMBOS", "BUFFER", "RESP"];
+                    reportSelect.innerHTML = "";
+                    for (var i = 0; i < order.length; i += 1) {
+                        var option = document.createElement("option");
+                        option.value = order[i];
+                        option.textContent = order[i];
+                        if (order[i] !== "AMBOS" && !availableSet[order[i]]) {
+                            option.disabled = true;
+                        }
+                        reportSelect.appendChild(option);
+                    }
+                    reportSelect.value = previousValue;
+                }
+
                 function pointsForDay(dayValue) {
                     var dayPoints = [];
                     for (var i = 0; i < pointsData.length; i += 1) {
@@ -772,7 +838,7 @@ class FilterPanel(MacroElement):
                     if (!points.length) {
                         return [];
                     }
-                    if (!reportValue || reportValue === "All" || reportValue === "AMBOS") {
+                    if (!reportValue || reportValue === "AMBOS" || reportValue === "All") {
                         return points.slice();
                     }
                     var filtered = [];
@@ -796,16 +862,10 @@ class FilterPanel(MacroElement):
                     }
 
                     var dayChanged = selectedDay !== lastSelections.day;
-                    populateSelect(
-                        reportSelect,
-                        collectUnique(basePoints, "report"),
-                        !dayChanged,
-                        [{ value: "AMBOS", label: "Ambos" }]
-                    );
+                    populateReportSelect(basePoints, !dayChanged);
 
-                    var selectedReport = reportSelect.value || "All";
-                    var normalizedReport = selectedReport === "AMBOS" ? "All" : selectedReport;
-                    var reportChanged = dayChanged || normalizedReport !== lastSelections.report;
+                    var selectedReport = reportSelect.value || "AMBOS";
+                    var reportChanged = dayChanged || selectedReport !== lastSelections.report;
 
                     var reportFiltered = filterByReport(basePoints, selectedReport);
 
@@ -852,7 +912,7 @@ class FilterPanel(MacroElement):
 
                     if (filtered.length === 0) {
                         lastSelections.day = selectedDay || "All";
-                        lastSelections.report = normalizedReport;
+                        lastSelections.report = selectedReport;
                         lastSelections.operator = opValue;
                         lastSelections.network = netValue;
                         return;
@@ -895,7 +955,7 @@ class FilterPanel(MacroElement):
                     }
 
                     lastSelections.day = selectedDay || "All";
-                    lastSelections.report = normalizedReport;
+                    lastSelections.report = selectedReport;
                     lastSelections.operator = opValue;
                     lastSelections.network = netValue;
                 }

--- a/viz/utils.py
+++ b/viz/utils.py
@@ -42,6 +42,13 @@ LON_CANDIDATES = [
 TIME_CANDIDATES = ["send_time", "gnss_utc_time", "timestamp", "created_at"]
 MCC_CANDIDATES = ["mcc", "mobile_country_code"]
 MNC_CANDIDATES = ["mnc", "mobile_network_code"]
+OPERATOR_CANDIDATES = [
+    "operador",
+    "operator",
+    "carrier",
+    "operador_celular",
+    "network_operator",
+]
 CSQ_CANDIDATES = ["csq", "csq_rssi", "csq_rsrp", "lte_csq"]
 CSQ_BER_CANDIDATES = ["csq_ber", "ber"]
 NETWORK_TYPE_CANDIDATES = ["network_type", "rat", "network"]
@@ -248,6 +255,7 @@ __all__ = [
     "TIME_CANDIDATES",
     "MCC_CANDIDATES",
     "MNC_CANDIDATES",
+    "OPERATOR_CANDIDATES",
     "CSQ_CANDIDATES",
     "CSQ_BER_CANDIDATES",
     "NETWORK_TYPE_CANDIDATES",


### PR DESCRIPTION
## Summary
- enrich GTINF lookups with nearest entries within 60 seconds, including operator updates, and propagate the data during database regeneration
- update map point synchronization to adopt the closest GTINF record (including operator values) and simplify the report-type filter to BUFFER/RESP/AMBOS in the interactive panel
- refresh the visualization tests and fixtures to reflect the tighter GTINF matching tolerance and the new operator handling

## Testing
- pytest tests/viz/test_mapa_recorridos.py

------
https://chatgpt.com/codex/tasks/task_e_68f7aef2fc2083339a6c2db648270d3f