### PR TITLE
Priorizar lectura de *_map.db en build_points (evita depender del enriquecedor) + test para gteri_gv350ceu_map.db

### DIFF
--- a/tests/viz/test_mapa_recorridos.py
+++ b/tests/viz/test_mapa_recorridos.py
@@ -340,3 +340,55 @@ def test_render_interactive_map_includes_filters(tmp_path: Path):
     assert 'value="RESP"' in html
     assert 'value="All"' in html
     assert 'Calidad de señal' in html
+
+
+def test_build_points_reads_existing_map_db(tmp_path: Path):
+    """
+    Si existe bases_sqlite/gteri_<modelo>_map.db con datos válidos,
+    build_points debe leerla directamente sin depender de ensure_enriched_database.
+    """
+
+    base_dir = tmp_path
+    model = "gv350ceu"
+    imei = "123456789012345"
+
+    db_path = base_dir / f"gteri_{model}_map.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        f"""
+        CREATE TABLE "gteri_{model}" (
+            imei TEXT,
+            send_time TEXT,
+            lat REAL,
+            lon REAL,
+            header TEXT,
+            operador TEXT,
+            tecnologia_celular TEXT,
+            calidad_senal TEXT
+        )
+        """
+    )
+    conn.executemany(
+        f'INSERT INTO "gteri_{model}" (imei, send_time, lat, lon, header, operador, tecnologia_celular, calidad_senal) '
+        'VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+        [
+            (imei, "20251016080000", -23.65, -70.4, "+RESP:GTERI", "Claro", "4G", "Excelente"),
+            (imei, "20251016083000", -23.66, -70.41, "+BUFF:GTERI", "Claro", "4G", "Buena"),
+            (imei, "20251017090000", -23.67, -70.42, "+RESP:GTERI", "Movistar", "3G", "Regular"),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    points = build_points(
+        model=model,
+        imei=imei,
+        base_dir=base_dir,
+        reports=["gteri"],
+    )
+
+    assert len(points) == 3
+    kinds = {point.report_kind for point in points}
+    assert kinds == {"BUFFER", "RESP"}
+    assert {point.operator for point in points} == {"Claro", "Movistar"}
+    assert {point.network_label for point in points} == {"4G", "3G"}

--- a/viz/mapa_recorridos.py
+++ b/viz/mapa_recorridos.py
@@ -1031,25 +1031,38 @@ def build_points(
     if not model_clean:
         raise ValueError("El modelo no puede estar vacío")
 
+    # Mantén el comportamiento actual: por defecto solo GTERI.
+    # (Si más adelante quieres soportar GTFRI por defecto, usa: ["gteri", "gtfri"])
     reports_to_use = [r.lower() for r in (reports or ["gteri"])]
+
     all_points: List[LocationPoint] = []
     searched_paths: List[Path] = []
     for report in reports_to_use:
         map_path = base_dir / f"{report}_{model_clean}_map.db"
+
+        # 1) Si ya existe la base enriquecida *_map.db, leerla directamente.
+        if map_path.exists():
+            searched_paths.append(map_path)
+            points = _load_locations_from_db(map_path, report, model_clean, imei)
+            all_points.extend(points)
+            continue
+
+        # 2) Si no existe, intenta generar/ubicar la ruta con ensure_enriched_database
         try:
-            ensure_enriched_database(
+            enriched_path = ensure_enriched_database(
                 report=report,
                 model=model_clean,
                 base_dir=base_dir,
                 imei=imei,
             )
+            searched_paths.append(enriched_path)
+            points = _load_locations_from_db(enriched_path, report, model_clean, imei)
+            all_points.extend(points)
         except FileNotFoundError:
+            # Registrar la ruta buscada para un mensaje de error claro más adelante.
             searched_paths.append(map_path)
-            continue
-
-        searched_paths.append(map_path)
-        points = _load_locations_from_db(map_path, report, model_clean, imei)
-        all_points.extend(points)
+            # Continuar con el siguiente reporte sin abortar.
+            pass
 
     if not all_points:
         existing_paths = list({path: None for path in searched_paths if path.exists()}.keys())


### PR DESCRIPTION
## Summary
- leer directamente bases_sqlite/<reporte>_<modelo>_map.db cuando existe, evitando depender de ensure_enriched_database
- solo invocar ensure_enriched_database cuando no haya *_map.db y usar la ruta que devuelve
- agregar prueba que valida que build_points consume gteri_gv350ceu_map.db con datos válidos

## Testing
- pytest tests/viz/test_mapa_recorridos.py

------
https://chatgpt.com/codex/tasks/task_e_68f7e598166483338bb743a077cc14f6