### PR TITLE
Fix safe JSON embedding in map filter panel

### DIFF
--- a/viz/mapa_recorridos.py
+++ b/viz/mapa_recorridos.py
@@ -698,7 +698,7 @@ class FilterPanel(MacroElement):
                     var pointsData;
                     var operatorColors;
                     try {
-                        pointsData = JSON.parse({{ this.points_json | tojson }});
+                        pointsData = JSON.parse({{ this.points_json | tojson | safe }});
                         operatorColors = JSON.parse({{ this.operator_colors_json | tojson }});
                     } catch (parseError) {
                         console.error("FilterPanel JSON parse error:", parseError);


### PR DESCRIPTION
## Summary
- ensure the filter panel points JSON is marked safe before embedding in the script to avoid syntax errors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f7f4e78c4c8333b9d25e8c84b59572