### PR TITLE
Fix JSON initialization in filter panel

### DIFF
--- a/viz/mapa_recorridos.py
+++ b/viz/mapa_recorridos.py
@@ -698,8 +698,8 @@ class FilterPanel(MacroElement):
                     var pointsData;
                     var operatorColors;
                     try {
-                        pointsData = JSON.parse({{ this.points_json | tojson | safe }});
-                        operatorColors = JSON.parse({{ this.operator_colors_json | tojson }});
+                        pointsData = {{ this.points_json | tojson | safe }};
+                        operatorColors = {{ this.operator_colors_json | tojson | safe }};
                     } catch (parseError) {
                         console.error("FilterPanel JSON parse error:", parseError);
                         return;


### PR DESCRIPTION
## Summary
- embed the filter panel point data directly as JSON objects instead of parsing strings
- mark both the point and operator color payloads as safe JSON so they can be consumed without syntax errors

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f8c00b588c83339917c3616d065518