### PR TITLE
Ajusta script del FilterPanel para logs y simplifica renderizado

### DIFF
--- a/viz/mapa_recorridos.py
+++ b/viz/mapa_recorridos.py
@@ -688,6 +688,8 @@ class FilterPanel(MacroElement):
 
             {% macro script(this, kwargs) %}
             (function(){
+              console.log("[FilterPanel] boot");
+
               // --- utilidades para resolver map_/figure_ creados por Folium ---
               function _findFoliumMapKey() {
                 for (var k in window) {
@@ -717,7 +719,7 @@ class FilterPanel(MacroElement):
                 var mapObj = window[mapKey];
 
                 // Datos inyectados desde Python:
-                const pointsData = {{ this.points_json | safe }};
+                const pointsData = JSON.parse({{ this.points_json | tojson }});
                 const operatorColors = {{ this.operator_colors_json | safe }};
 
                 // Referencias a selects del panel de filtros
@@ -881,55 +883,6 @@ class FilterPanel(MacroElement):
 
             """
         )
-
-    def render(self, **kwargs):  # type: ignore[override]
-        """Renderiza el panel y reubica el bloque de scripts al final del body.
-
-        Folium/Branca inserta por defecto los scripts de los MacroElement en el
-        contenedor ``figure.script`` inmediatamente después de renderizar el
-        elemento.  Para garantizar que el script del panel se ejecute una vez
-        que ``figure_*`` y el mapa base ya han sido definidos, volvemos a
-        insertar el bloque asociado al panel al final del contenedor de
-        scripts.
-        """
-
-        parent_render = getattr(super(), "render", None)
-        if parent_render is None:
-            return
-
-        parent_render(**kwargs)
-
-        figure = getattr(self, "_parent", None)
-        if figure is None:
-            figure = self.get_root()
-
-        script_container = getattr(figure, "script", None)
-        if script_container is None:
-            return
-
-        children = getattr(script_container, "_children", None)
-        if not isinstance(children, dict) or not children:
-            return
-
-        name_getter = getattr(self, "get_name", None)
-        if name_getter is None:
-            return
-
-        script_key = None
-        panel_name = name_getter()
-        if panel_name in children:
-            script_key = panel_name
-        else:
-            for key in children:
-                if key.endswith(panel_name):
-                    script_key = key
-                    break
-
-        if script_key is None:
-            return
-
-        script_element = children.pop(script_key)
-        children[script_key] = script_element
 
 
 def render_interactive_map(


### PR DESCRIPTION
## Summary
- agrega un log de arranque al script del FilterPanel y expone los datos mediante JSON.parse para mayor seguridad
- elimina el override personalizado de render para que Folium gestione el bloque de scripts de manera predeterminada

## Testing
- no se ejecutaron pruebas (no aplicable)

------
https://chatgpt.com/codex/tasks/task_e_68f8e6e10de0833389a526b6f4d9bf2b