### PR TITLE
Fix JSON injection in map filter panel

### DIFF
--- a/viz/mapa_recorridos.py
+++ b/viz/mapa_recorridos.py
@@ -718,8 +718,8 @@ class FilterPanel(MacroElement):
                 if (!figKey || !mapKey) return setTimeout(_initFilterPanel, 50);
                 var mapObj = window[mapKey];
 
-                // Datos inyectados desde Python:
-                const pointsData = JSON.parse({{ this.points_json | tojson }});
+                // Datos inyectados desde Python (ya es JSON válido):
+                const pointsData = {{ this.points_json | safe }};
                 const operatorColors = {{ this.operator_colors_json | safe }};
 
                 // Referencias a selects del panel de filtros


### PR DESCRIPTION
## Summary
- inject the pre-serialized points data directly into the template to avoid double-stringifying it

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f8f12275e4833388e6fb2a143ef719