### PR TITLE
Arreglar error de sintaxis por comillas en console.error del FilterPanel

### DIFF
--- a/viz/mapa_recorridos.py
+++ b/viz/mapa_recorridos.py
@@ -715,7 +715,7 @@ class FilterPanel(MacroElement):
                 console.debug("[FilterPanel] boot");
 
                 if (document.querySelector('script[src^="data:application/json;base64"]')) {
-                  console.error("[FilterPanel] Detectado <script src=\"data:application/json;base64,…\"> en el HTML. Esto no lo genera esta versión del código.");
+                  console.error(`[FilterPanel] Detectado <script src="data:application/json;base64,…"> en el HTML. Esto no lo genera esta versión del código.`);
                 }
 
                 var figKey = _findFoliumFigureKey();


### PR DESCRIPTION
## Summary
- corregir la cadena de `console.error` del FilterPanel para evitar el cierre prematuro por comillas dobles

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f952572c0c8333842627c46d4cc680