### PR TITLE
Refactor mapa_recorridos to maintain enriched map databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,39 +111,29 @@ El comando anterior creará los archivos:
 
 Para más ejemplos y capturas de pantalla revisa `docs/viz/mapas.md`.
 
-## Mapas interactivos por IMEI y operador
+## Bases enriquecidas por IMEI y operador
 
-La funcionalidad descrita en `docs/viz/mapa_recorridos_por_imei.md` genera un mapa HTML
-que combina los reportes de posición (`GTERI`/`GTFRI`) con la información de red (`GTINF`).
-Cada punto adopta la última medición `GTINF` cuyo `send_time` sea menor o igual, por lo que
-los tramos del recorrido heredan la tecnología (2G/3G/4G) y la calidad de señal asociadas a
-la red disponible en ese instante.
+`viz/mapa_recorridos.py` ya no genera archivos HTML ni GeoJSON. Su responsabilidad es crear y
+mantener las bases `gteri_<modelo>_map.db` y `gtfri_<modelo>_map.db`, cruzando automáticamente
+las ubicaciones (`GTERI`/`GTFRI`) con la información de red proveniente de `GTINF`.
 
-Características destacadas:
+El proceso agrega/actualiza las columnas `tecnologia_celular`, `calidad_senal`,
+`nivel_senal_dbm` y `operador`, rellenándolas con la mejor medición `GTINF` disponible para cada
+`send_time` del recorrido. También normaliza el operador a los nombres locales (Entel, Movistar,
+Claro, WOM o Desconocido) cuando solo se dispone de MCC/MNC.
 
-- Capas independientes por operador, tecnología y día.
-- Tooltips con IMEI, coordenadas, reporte origen, tecnología, clasificación de señal y valores
-  de CSQ/BER cuando estén presentes.
-- Corrección automática de coordenadas cuando los reportes invierten latitud/longitud, incluso
-  si la trama no incluye códigos MCC.
-- Los recorridos y filtros se construyen exclusivamente a partir de las bases enriquecidas
-  `<reporte>_<modelo>_map.db`, que ahora incluyen una columna `operador` con el nombre del
-  carrier normalizado (Entel, Movistar, Claro, WOM o Desconocido).
-- Filtros `--day`, `--operator`, `--network` y `--report`, todos compatibles con la palabra
-  clave `All` para desactivar la restricción.
-
-Ejecución básica:
+Ejemplo de ejecución:
 
 ```bash
 python generate_map.py \
   --model gv350ceu \
-  --imei 862524060869597 \
-  --db-dir bases_sqlite \
-  --out-dir mapas
+  --db-dir bases_sqlite
 ```
 
-Consulta la guía completa para más ejemplos, la explicación del algoritmo de fusión y las
-consideraciones de uso.
+El comando anterior creará o actualizará las bases enriquecidas disponibles en `bases_sqlite`.
+Si se solicita un reporte que no exista (por ejemplo `gtfri`), el script emitirá una advertencia
+indicando el archivo faltante. Usa `--report` para acotar qué reportes procesar y `--strict`
+cuando prefieras que la ejecución falle ante cualquier ausencia.
 
 ## Pruebas
 

--- a/generate_map.py
+++ b/generate_map.py
@@ -1,4 +1,4 @@
-"""Script de conveniencia para generar mapas interactivos por IMEI."""
+"""Script de conveniencia para actualizar las bases de recorridos enriquecidas."""
 from __future__ import annotations
 
 from typing import Optional, Sequence

--- a/tests/viz/test_mapa_recorridos.py
+++ b/tests/viz/test_mapa_recorridos.py
@@ -1,189 +1,24 @@
+from __future__ import annotations
+
 import sqlite3
-from datetime import datetime, timedelta
 from pathlib import Path
 
 import pytest
 
-from viz.mapa_recorridos import (
-    InfoRecord,
-    LocationPoint,
-    _associate_info,
-    _filter_points,
-    _normalize_operator,
-    _report_kind_from_header,
-    _safe_int,
-    build_points,
-    render_interactive_map,
-)
-from viz.enriched_db import ensure_enriched_database
+from viz.mapa_recorridos import ensure_map_databases
 
 
-def test_safe_int_parses_leading_zero_decimal():
-    assert _safe_int("0730") == 730
-    assert _safe_int("0009") == 9
-
-
-def test_safe_int_keeps_base_prefix_support():
-    assert _safe_int("0x10") == 16
-
-
-def test_normalize_operator_known_chile_carriers():
-    assert _normalize_operator(730, 2) == "Movistar"
-    assert _normalize_operator(730, 9) == "WOM"
-    assert _normalize_operator(None, 9) == "WOM"
-    assert _normalize_operator(472, 9) == "Desconocido"
-
-
-def test_normalize_operator_requires_mnc():
-    assert _normalize_operator(730, None) == "Desconocido"
-
-
-def test_report_kind_from_header_detects_buffer_and_resp():
-    assert _report_kind_from_header("+BUFF:GTERI") == "BUFFER"
-    assert _report_kind_from_header("+RESP:GTFRI") == "RESP"
-    assert _report_kind_from_header("other") == "RESP"
-
-
-def _make_point(
-    offset_seconds: int,
-    *,
-    operator: str = "Entel",
-    network: str = "Desconocida",
-) -> LocationPoint:
-    base = datetime(2025, 10, 10, 0, 0, 0)
-    return LocationPoint(
-        lat=0.0,
-        lon=0.0,
-        send_time=base + timedelta(seconds=offset_seconds),
-        imei="123456789012345",
-        source="gteri",
-        operator=operator,
-        network_label=network,
-    )
-
-
-def _make_info(
-    offset_seconds: int,
-    *,
-    label: str,
-    csq: float,
-    csq_ber: int | None = None,
-    operator: str = "Desconocido",
-) -> InfoRecord:
-    base = datetime(2025, 10, 10, 0, 0, 0)
-    return InfoRecord(
-        imei="123456789012345",
-        send_time=base + timedelta(seconds=offset_seconds),
-        network_label=label,
-        raw_network_value=None,
-        csq=csq,
-        csq_ber=csq_ber,
-        operator=operator,
-    )
-
-
-def test_associate_info_uses_latest_previous_record():
-    points = [
-        _make_point(0),
-        _make_point(20),
-        _make_point(70),
-        _make_point(120),
-    ]
-    infos = [
-        _make_info(0, label="3G", csq=15, csq_ber=3),
-        _make_info(100, label="4G", csq=160),
-    ]
-
-    _associate_info(points, infos)
-
-    assert [point.network_label for point in points] == ["3G", "3G", "4G", "4G"]
-    assert [point.signal_quality for point in points] == [
-        "Buena",
-        "Buena",
-        "Excelente",
-        "Excelente",
-    ]
-
-
-def test_associate_info_ignores_info_farther_than_one_minute():
-    points = [_make_point(0), _make_point(10)]
-    infos = [_make_info(200, label="2G", csq=25)]
-
-    _associate_info(points, infos)
-
-    assert points[0].network_label == "Desconocida"
-    assert points[0].signal_quality == "Desconocida"
-    assert points[1].network_label == "Desconocida"
-    assert points[1].signal_quality == "Desconocida"
-
-
-def test_associate_info_updates_operator_when_available():
-    points = [_make_point(0, operator="Desconocido")]
-    infos = [_make_info(0, label="3G", csq=15, operator="Claro")]
-
-    _associate_info(points, infos)
-
-    assert points[0].operator == "Claro"
-
-
-def test_filter_points_accepts_all_keyword_for_every_filter():
-    points = [
-        _make_point(0, operator="Claro", network="2G"),
-        _make_point(60, operator="Entel", network="3G"),
-        _make_point(120, operator="Movistar", network="4G"),
-    ]
-
-    assert _filter_points(points, operators=["All"]) == points
-    assert _filter_points(points, networks=["ALL"]) == points
-    assert _filter_points(points, report_types=["All"]) == points
-    assert _filter_points(points, report_types=["AMBOS"]) == points
-    assert _filter_points(points, day="Todos") == points
-
-
-def test_filter_points_day_filter_has_priority():
-    day_one_point = _make_point(0, operator="Claro", network="3G")
-    day_two_point = _make_point(86400, operator="Claro", network="3G")
-    extra_day_two = _make_point(86400 + 60, operator="Entel", network="2G")
-
-    points = [day_one_point, day_two_point, extra_day_two]
-
-    result = _filter_points(
-        points,
-        day="2025-10-10",
-        operators=["Claro"],
-        networks=["3G"],
-    )
-
-    assert result == [day_one_point]
-
-
-def test_filter_points_respects_report_types():
-    buffer_point = _make_point(0, operator="Claro", network="3G")
-    buffer_point.report_kind = "BUFFER"
-    resp_point = _make_point(60, operator="Entel", network="4G")
-    resp_point.report_kind = "RESP"
-
-    points = [buffer_point, resp_point]
-
-    assert _filter_points(points, report_types=["BUFFER"]) == [buffer_point]
-    assert _filter_points(points, report_types=["RESP"]) == [resp_point]
-    assert _filter_points(
-        points,
-        day="2025-10-10",
-        report_types=["BUFFER"],
-        operators=["Claro"],
-    ) == [buffer_point]
-
-
-def _prepare_map_databases(tmp_path: Path) -> tuple[Path, str, str]:
+def _setup_sources(tmp_path: Path) -> tuple[Path, str, str]:
     base_dir = tmp_path
     model = "gv350ceu"
     imei = "123456789012345"
-    map_path = base_dir / f"gteri_{model}_map.db"
-    conn = sqlite3.connect(map_path)
+
+    gteri_source = base_dir / f"gteri_{model}.db"
+    conn = sqlite3.connect(gteri_source)
+    table_name = f"gteri_{model}"
     conn.execute(
         f"""
-        CREATE TABLE "gteri_{model}" (
+        CREATE TABLE "{table_name}" (
             imei TEXT,
             send_time TEXT,
             lat REAL,
@@ -196,49 +31,23 @@ def _prepare_map_databases(tmp_path: Path) -> tuple[Path, str, str]:
         """
     )
     conn.executemany(
-        f'INSERT INTO "gteri_{model}" (imei, send_time, lat, lon, header, operador, tecnologia_celular, calidad_senal) '
+        f'INSERT INTO "{table_name}" (imei, send_time, lat, lon, header, operador, tecnologia_celular, calidad_senal) '
         'VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
         [
-            (
-                imei,
-                "20251016080000",
-                -33.45,
-                -70.66,
-                "+RESP:GTERI",
-                "",
-                "",
-                "",
-            ),
-            (
-                imei,
-                "20251016083000",
-                -33.46,
-                -70.65,
-                "+BUFF:GTERI",
-                "",
-                "",
-                "",
-            ),
-            (
-                imei,
-                "20251017090000",
-                -33.47,
-                -70.64,
-                "+RESP:GTERI",
-                "",
-                "",
-                "",
-            ),
+            (imei, "20251016080000", -33.45, -70.66, "+RESP:GTERI", "", "", ""),
+            (imei, "20251016083000", -33.46, -70.65, "+BUFF:GTERI", "", "", ""),
+            (imei, "20251017090000", -33.47, -70.64, "+RESP:GTERI", "", "", ""),
         ],
     )
     conn.commit()
     conn.close()
 
-    gtinf_path = base_dir / f"gtinf_{model}_map.db"
-    conn = sqlite3.connect(gtinf_path)
+    gtinf_source = base_dir / f"gtinf_{model}.db"
+    conn = sqlite3.connect(gtinf_source)
+    table_name = f"gtinf_{model}"
     conn.execute(
         f"""
-        CREATE TABLE "gtinf_{model}" (
+        CREATE TABLE "{table_name}" (
             imei TEXT,
             send_time TEXT,
             network_type INTEGER,
@@ -249,7 +58,7 @@ def _prepare_map_databases(tmp_path: Path) -> tuple[Path, str, str]:
         """
     )
     conn.executemany(
-        f'INSERT INTO "gtinf_{model}" (imei, send_time, network_type, csq, csq_ber, operador) '
+        f'INSERT INTO "{table_name}" (imei, send_time, network_type, csq, csq_ber, operador) '
         'VALUES (?, ?, ?, ?, ?, ?)',
         [
             (imei, "20251016080000", 3, 160, None, "Claro"),
@@ -263,149 +72,42 @@ def _prepare_map_databases(tmp_path: Path) -> tuple[Path, str, str]:
     return base_dir, model, imei
 
 
-def test_build_points_reads_map_database(tmp_path: Path):
-    base_dir, model, imei = _prepare_map_databases(tmp_path)
+def test_ensure_map_databases_generates_enriched_copy(tmp_path: Path) -> None:
+    base_dir, model, _ = _setup_sources(tmp_path)
 
-    ensure_enriched_database(report="gteri", model=model, base_dir=base_dir)
+    results = ensure_map_databases(model=model, base_dir=base_dir, reports=["gteri"])
 
-    points = build_points(
-        model=model,
-        imei=imei,
-        base_dir=base_dir,
-        reports=["gteri"],
-    )
+    assert set(results) == {"gteri"}
+    db_path = results["gteri"]
+    assert db_path.exists()
 
-    assert len(points) == 3
-    summary = [
-        (
-            point.send_time.strftime("%Y%m%d%H%M%S"),
-            point.report_kind,
-            point.operator,
-            point.network_label,
-            point.signal_quality,
-            point.day_iso,
-        )
-        for point in points
-    ]
-    assert summary == [
-        ("20251016080000", "RESP", "Claro", "4G", "Excelente", "2025-10-16"),
-        ("20251016083000", "BUFFER", "Claro", "4G", "Buena", "2025-10-16"),
-        ("20251017090000", "RESP", "Movistar", "3G", "Regular", "2025-10-17"),
-    ]
-
-
-def test_build_points_supports_whitespace_imei(tmp_path: Path):
-    base_dir, model, imei = _prepare_map_databases(tmp_path)
-    map_path = base_dir / f"gteri_{model}_map.db"
-    conn = sqlite3.connect(map_path)
-    conn.execute(
-        f'UPDATE "gteri_{model}" SET imei = ? WHERE send_time = ?',
-        (f"  {imei}\r\n", "20251016080000"),
-    )
-    conn.commit()
-    conn.close()
-
-    ensure_enriched_database(report="gteri", model=model, base_dir=base_dir)
-
-    points = build_points(
-        model=model,
-        imei=imei,
-        base_dir=base_dir,
-        reports=["gteri"],
-    )
-
-    assert len(points) == 3
-
-
-def test_render_interactive_map_includes_filters(tmp_path: Path):
-    pytest.importorskip("folium")
-    base_dir, model, imei = _prepare_map_databases(tmp_path)
-
-    ensure_enriched_database(report="gteri", model=model, base_dir=base_dir)
-
-    points = build_points(
-        model=model,
-        imei=imei,
-        base_dir=base_dir,
-        reports=["gteri"],
-    )
-
-    output_html = tmp_path / "mapa.html"
-    render_interactive_map(points, output_html)
-
-    html = output_html.read_text(encoding="utf-8")
-    assert 'data-filter-panel="interactive-filters"' in html
-    assert 'value="AMBOS"' in html
-    assert 'value="BUFFER"' in html
-    assert 'value="RESP"' in html
-    assert 'value="All"' in html
-    assert 'Calidad de señal' in html
-
-
-def test_build_points_reads_existing_map_db(tmp_path: Path):
-    """
-    Si existe bases_sqlite/gteri_<modelo>_map.db con datos válidos,
-    build_points debe leerla directamente sin depender de ensure_enriched_database.
-    """
-
-    base_dir = tmp_path
-    model = "gv350ceu"
-    imei = "123456789012345"
-
-    db_path = base_dir / f"gteri_{model}_map.db"
     conn = sqlite3.connect(db_path)
-    conn.execute(
-        f"""
-        CREATE TABLE "gteri_{model}" (
-            imei TEXT,
-            send_time TEXT,
-            lat REAL,
-            lon REAL,
-            header TEXT,
-            operador TEXT,
-            tecnologia_celular TEXT,
-            calidad_senal TEXT
-        )
-        """
-    )
-    conn.executemany(
-        f'INSERT INTO "gteri_{model}" (imei, send_time, lat, lon, header, operador, tecnologia_celular, calidad_senal) '
-        'VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
-        [
-            (imei, "20251016080000", -23.65, -70.4, "+RESP:GTERI", "Claro", "4G", "Excelente"),
-            (imei, "20251016083000", -23.66, -70.41, "+BUFF:GTERI", "Claro", "4G", "Buena"),
-            (imei, "20251017090000", -23.67, -70.42, "+RESP:GTERI", "Movistar", "3G", "Regular"),
-        ],
-    )
-    conn.commit()
+    rows = conn.execute(
+        f'SELECT send_time, tecnologia_celular, calidad_senal, operador '
+        f'FROM "gteri_{model}" ORDER BY send_time'
+    ).fetchall()
     conn.close()
 
-    points = build_points(
-        model=model,
-        imei=imei,
-        base_dir=base_dir,
-        reports=["gteri"],
-    )
-
-    assert len(points) == 3
-    kinds = {point.report_kind for point in points}
-    assert kinds == {"BUFFER", "RESP"}
-    assert {point.operator for point in points} == {"Claro", "Movistar"}
-    assert {point.network_label for point in points} == {"4G", "3G"}
+    summary = [tuple(row) for row in rows]
+    assert summary == [
+        ("20251016080000", "4G", "Excelente", "Claro"),
+        ("20251016083000", "4G", "Buena", "Claro"),
+        ("20251017090000", "3G", "Regular", "Movistar"),
+    ]
 
 
-def test_points_have_valid_lat_lon(tmp_path: Path):
-    base_dir, model, imei = _prepare_map_databases(tmp_path)
+def test_ensure_map_databases_warns_when_report_missing(tmp_path: Path) -> None:
+    base_dir, model, _ = _setup_sources(tmp_path)
 
-    ensure_enriched_database(report="gteri", model=model, base_dir=base_dir)
+    with pytest.warns(RuntimeWarning):
+        results = ensure_map_databases(model=model, base_dir=base_dir)
 
-    points = build_points(
-        model=model,
-        imei=imei,
-        base_dir=base_dir,
-        reports=["gteri"],
-    )
+    assert "gteri" in results
+    assert "gtfri" not in results
 
-    for point in points:
-        assert -90 <= point.lat <= 90
-        assert -180 <= point.lon <= 180
+
+def test_ensure_map_databases_strict_raises_on_missing(tmp_path: Path) -> None:
+    base_dir, model, _ = _setup_sources(tmp_path)
+
+    with pytest.raises(FileNotFoundError):
+        ensure_map_databases(model=model, base_dir=base_dir, reports=["gtfri"], strict=True)

--- a/viz/mapa_recorridos.py
+++ b/viz/mapa_recorridos.py
@@ -1,1131 +1,129 @@
-"""Generación de mapas interactivos por IMEI usando bases SQLite de reportes Queclink."""
+"""Mantenimiento de bases SQLite enriquecidas para recorridos por IMEI."""
+
 from __future__ import annotations
 
 import argparse
-import json
-import sqlite3
-from bisect import bisect_left
-from dataclasses import dataclass
-from datetime import datetime
-from decimal import Decimal, InvalidOperation
+import warnings
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional, Sequence, Tuple
-
-try:  # pragma: no cover - dependencia opcional en tiempo de ejecución
-    import folium
-    from folium import Map
-    _FOLIUM_IMPORT_ERROR: ModuleNotFoundError | None = None
-except ModuleNotFoundError as exc:  # pragma: no cover - entorno sin folium
-    folium = None  # type: ignore[assignment]
-    Map = None  # type: ignore[assignment]
-    _FOLIUM_IMPORT_ERROR = ModuleNotFoundError(
-        "folium no está instalado. Ejecuta 'pip install folium pytz python-dateutil'"
-    )
-
-try:  # pragma: no cover - dependencia opcional
-    from branca.element import MacroElement
-except ModuleNotFoundError:  # pragma: no cover - entorno sin branca
-    MacroElement = object  # type: ignore[assignment]
-    if '_FOLIUM_IMPORT_ERROR' in globals() and _FOLIUM_IMPORT_ERROR is None:
-        _FOLIUM_IMPORT_ERROR = ModuleNotFoundError(
-            "branca no está instalado. Ejecuta 'pip install folium pytz python-dateutil'"
-        )
-
-try:  # pragma: no cover - dependencia opcional
-    from jinja2 import Template
-except ModuleNotFoundError:  # pragma: no cover - entorno sin jinja2
-    Template = None  # type: ignore[assignment]
-    if '_FOLIUM_IMPORT_ERROR' in globals() and _FOLIUM_IMPORT_ERROR is None:
-        _FOLIUM_IMPORT_ERROR = ModuleNotFoundError(
-            "jinja2 no está instalado. Ejecuta 'pip install folium pytz python-dateutil'"
-        )
-
-from src.ingestors.sqlite_records import ensure_db
+from typing import Dict, Iterable, Optional, Sequence
 
 from .enriched_db import ensure_enriched_database
-from .utils import (
-    CSQ_BER_CANDIDATES,
-    CSQ_CANDIDATES,
-    IMEI_CANDIDATES,
-    MCC_CANDIDATES,
-    MNC_CANDIDATES,
-    NETWORK_TYPE_CANDIDATES,
-    NETWORK_TYPE_MAP,
-    OPERATOR_CANDIDATES,
-    TIME_CANDIDATES,
-    classify_signal as _classify_signal,
-    detect_table as _detect_table,
-    first_existing as _first_existing,
-    load_table_schema as _load_table_schema,
-    normalize_operator as _normalize_operator,
-    parse_datetime as _parse_datetime,
-    safe_float as _safe_float,
-    safe_int as _safe_int,
-)
 
-# Tipos auxiliares -----------------------------------------------------------
+_DEFAULT_REPORTS: tuple[str, ...] = ("gteri", "gtfri")
 
 
-@dataclass
-class LocationPoint:
-    lat: float
-    lon: float
-    send_time: datetime
-    imei: str
-    source: str
-    operator: str
-    report_kind: str = "RESP"
-    mcc: Optional[int] = None
-    mnc: Optional[int] = None
-    raw_payload: Optional[dict] = None
-    network_label: str = "Desconocida"
-    signal_quality: str = "Desconocida"
-    signal_dbm: Optional[float] = None
-    csq: Optional[float] = None
-    csq_ber: Optional[int] = None
-    day_iso: Optional[str] = None
+def _normalize_report(report: str) -> str:
+    value = report.strip().lower()
+    if not value:
+        raise ValueError("El nombre del reporte no puede estar vacío")
+    return value
 
 
-@dataclass
-class InfoRecord:
-    imei: str
-    send_time: datetime
-    network_label: str
-    raw_network_value: Optional[int]
-    csq: Optional[float] = None
-    csq_ber: Optional[int] = None
-    operator: str = "Desconocido"
-
-NETWORK_COLORS = {
-    "2G": "#1f77b4",
-    "3G": "#ff7f0e",
-    "4G": "#2ca02c",
-    "Sin servicio": "#7f7f7f",
-    "Desconocida": "#7f7f7f",
-}
-
-OPERATOR_COLORS = {
-    "Entel": "#1f77b4",
-    "Claro": "#ff7f0e",
-    "Movistar": "#2ca02c",
-    "WOM": "#9467bd",
-    "Desconocido": "#7f7f7f",
-}
-
-_ASSOCIATION_MAX_DELTA_SECONDS = 60
-
-# Tipos de reporte -----------------------------------------------------------
-
-
-def _normalize_text(value: object) -> str:
-    if value in (None, ""):
-        return ""
-    if isinstance(value, bytes):
-        try:
-            return value.decode("utf-8", errors="ignore")
-        except Exception:  # pragma: no cover - fallback de decodificación
-            return value.decode("latin-1", errors="ignore")
-    return str(value)
-
-
-def _parse_send_time(value: object) -> Optional[datetime]:
-    text = _normalize_text(value)
-    if not text:
-        return None
-    if len(text) >= 14 and text[:14].isdigit():
-        try:
-            return datetime.strptime(text[:14], "%Y%m%d%H%M%S")
-        except ValueError:
-            return None
-    try:
-        return datetime.fromisoformat(text)
-    except ValueError:
-        return None
-
-
-def _day_iso(value: Optional[datetime]) -> Optional[str]:
-    return value.date().isoformat() if value else None
-
-
-def _report_kind_from_header(header: object) -> str:
-    text = _normalize_text(header).upper()
-    if text.startswith("+BUFF:"):
-        return "BUFFER"
-    if text.startswith("+RESP:"):
-        return "RESP"
-    return "RESP"
-
-
-# Utilidades internas --------------------------------------------------------
-
-
-def _valid_coordinates(lat: float, lon: float) -> bool:
-    return -90.0 <= lat <= 90.0 and -180.0 <= lon <= 180.0
-
-
-def _swap_coordinates_if_needed(
-    lat: float, lon: float, mcc: Optional[int]
-) -> Tuple[float, float]:
-    candidate_lat, candidate_lon = lon, lat
-    swap_valid = _valid_coordinates(candidate_lat, candidate_lon)
-
-    if swap_valid:
-        if abs(lat) > 90.0 or abs(lon) > 180.0:
-            return candidate_lat, candidate_lon
-        if abs(lat) > abs(lon):
-            return candidate_lat, candidate_lon
-
-    if abs(lat) > 90.0 and abs(lon) <= 90.0 and swap_valid:
-        return candidate_lat, candidate_lon
-
-    if mcc == 730 and abs(lat) > 60.0 and abs(lon) < 80.0 and swap_valid:
-        return candidate_lat, candidate_lon
-
-    if abs(lat) > 60.0 and swap_valid and not (-60.0 <= lat <= 60.0):
-        if -60.0 <= candidate_lat <= 60.0:
-            return candidate_lat, candidate_lon
-
-    return lat, lon
-
-
-def _require_folium() -> None:
-    if _FOLIUM_IMPORT_ERROR is not None:
-        raise _FOLIUM_IMPORT_ERROR
-
-def _normalized_imei_value(value: object) -> str:
-    if value in (None, ""):
-        return ""
-
-    text = str(value).strip()
-    if not text:
-        return ""
-
-    # Algunos archivos SQLite almacenan el IMEI como número en notación
-    # científica (por ejemplo ``8.68589060824888e+14``). En esos casos
-    # intentamos decodificarlo como entero antes de aplicar una limpieza
-    # genérica para mantener la compatibilidad con bases históricas.
-    if any(ch in text for ch in ".eE"):
-        try:
-            number = Decimal(text)
-        except (InvalidOperation, ValueError):
-            number = None
-        else:
-            if number == number.to_integral_value():
-                return str(int(number))
-
-    digits = "".join(ch for ch in text if ch.isdigit())
-    if digits:
-        return digits
-
-    return "".join(ch for ch in text if ch.isalnum())
-
-
-def _normalized_imei_expression(column: str) -> str:
-    return f'normalize_imei("{column}")'
-
-
-def _register_sqlite_helpers(conn: sqlite3.Connection) -> None:
-    conn.create_function("normalize_imei", 1, _normalized_imei_value)
-
-
-# Lectura de datos -----------------------------------------------------------
-
-
-_LOCATION_COLUMN_CANDIDATES = {
-    "imei": IMEI_CANDIDATES,
-    "lat": ["lat"],
-    "lon": ["lon"],
-    "send_time": ["send_time"],
-    "header": ["header"],
-    "operator": ["operador"],
-    "network": ["tecnologia_celular"],
-    "signal_quality": ["calidad_senal"],
-}
-
-
-def _resolve_location_table(
-    conn: sqlite3.Connection, report: str, model: str, imei: str
-) -> tuple[str, dict[str, str]]:
-    try:
-        primary_table = _detect_table(conn, report, model, imei)
-    except Exception:
-        primary_table = None
-
-    rows = conn.execute(
-        "SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name"
-    ).fetchall()
-    table_names = [row[0] for row in rows]
-    ordered_tables: List[str] = []
-    if primary_table:
-        ordered_tables.append(primary_table)
-    for name in table_names:
-        if name not in ordered_tables:
-            ordered_tables.append(name)
-
-    for table in ordered_tables:
-        columns = _load_table_schema(conn, table)
-        column_map: dict[str, str] = {}
-        for key, candidates in _LOCATION_COLUMN_CANDIDATES.items():
-            column = _first_existing(candidates, columns)
-            if not column:
-                column_map = {}
-                break
-            column_map[key] = column
-        if column_map:
-            return table, column_map
-
-    raise ValueError(
-        "No se encontró una tabla con las columnas requeridas para ubicaciones"
-    )
-
-
-def _load_locations_from_db(
-    db_path: Path,
-    report: str,
-    model: str,
-    imei: str,
-) -> List[LocationPoint]:
-    if not db_path.exists():
-        return []
-
-    conn = ensure_db(db_path)
-    _register_sqlite_helpers(conn)
-    conn.row_factory = sqlite3.Row
-    try:
-        table, column_map = _resolve_location_table(conn, report, model, imei)
-
-        imei_col = column_map["imei"]
-        lat_col = column_map["lat"]
-        lon_col = column_map["lon"]
-        time_col = column_map["send_time"]
-        header_col = column_map["header"]
-        operator_col = column_map["operator"]
-        network_col = column_map["network"]
-        signal_col = column_map["signal_quality"]
-
-        sql = f"""
-        SELECT
-            "{header_col}" AS header,
-            "{lat_col}" AS lat,
-            "{lon_col}" AS lon,
-            "{time_col}" AS send_time,
-            "{operator_col}" AS operador,
-            "{network_col}" AS tecnologia_celular,
-            "{signal_col}" AS calidad_senal
-        FROM "{table}"
-        WHERE {_normalized_imei_expression(imei_col)} = :imei
-        ORDER BY "{time_col}"
-        """
-
-        normalized_imei = _normalized_imei_value(imei)
-        rows = conn.execute(sql, {"imei": normalized_imei}).fetchall()
-
-        points: List[LocationPoint] = []
-        for row in rows:
-            raw_payload = dict(row)
-
-            lat_value = raw_payload.get("latitude")
-            if lat_value is None:
-                lat_value = raw_payload.get("lat")
-            lon_value = raw_payload.get("longitude")
-            if lon_value is None:
-                lon_value = raw_payload.get("lon")
-
-            if lat_value is None or lon_value is None:
-                raise ValueError(f"Fila sin lat/lon: {raw_payload}")
-
-            lat = _safe_float(lat_value)
-            lon = _safe_float(lon_value)
-            send_dt = _parse_send_time(row["send_time"])
-            if lat is None or lon is None or send_dt is None:
-                continue
-
-            lat = float(lat)
-            lon = float(lon)
-
-            if abs(lat) > 90.0 or abs(lon) > 180.0 or abs(lat) > abs(lon):
-                lat, lon = lon, lat
-
-            # Corrige lat/lon intercambiadas cuando aplique
-            lat, lon = _swap_coordinates_if_needed(lat, lon, None)
-            if not _valid_coordinates(lat, lon):
-                continue
-            operator_value = _normalize_text(row["operador"]).strip() or "Desconocido"
-            network_label = _normalize_text(row["tecnologia_celular"]) or "Desconocida"
-            signal_quality = _normalize_text(row["calidad_senal"]) or "Desconocida"
-            points.append(
-                LocationPoint(
-                    lat=float(lat),
-                    lon=float(lon),
-                    send_time=send_dt,
-                    imei=imei,
-                    source=report.lower(),
-                    operator=operator_value,
-                    report_kind=_report_kind_from_header(row["header"]),
-                    raw_payload=raw_payload,
-                    network_label=network_label or "Desconocida",
-                    signal_quality=signal_quality or "Desconocida",
-                    day_iso=_day_iso(send_dt),
-                )
-            )
-        return points
-    finally:
-        conn.close()
-
-
-def _load_gtinf_records(db_path: Path, model: str, imei: str) -> List[InfoRecord]:
-    if not db_path.exists():
-        return []
-
-    conn = ensure_db(db_path)
-    _register_sqlite_helpers(conn)
-    conn.row_factory = sqlite3.Row
-    table = _detect_table(conn, "gtinf", model, imei)
-    columns = _load_table_schema(conn, table)
-
-    imei_col = _first_existing(IMEI_CANDIDATES, columns)
-    time_col = _first_existing(TIME_CANDIDATES, columns)
-    network_col = _first_existing(NETWORK_TYPE_CANDIDATES, columns)
-    if not imei_col or not time_col or not network_col:
-        raise ValueError(f"La tabla {table} no tiene columnas necesarias para GTINF")
-
-    csq_col = _first_existing(CSQ_CANDIDATES, columns)
-    ber_col = _first_existing(CSQ_BER_CANDIDATES, columns)
-    operator_col = _first_existing(OPERATOR_CANDIDATES, columns)
-    mcc_col = _first_existing(MCC_CANDIDATES, columns)
-    mnc_col = _first_existing(MNC_CANDIDATES, columns)
-
-    query_cols = {imei_col, time_col, network_col}
-    if csq_col:
-        query_cols.add(csq_col)
-    if ber_col:
-        query_cols.add(ber_col)
-    if operator_col:
-        query_cols.add(operator_col)
-    if mcc_col:
-        query_cols.add(mcc_col)
-    if mnc_col:
-        query_cols.add(mnc_col)
-
-    imei_expr = _normalized_imei_expression(imei_col)
-    select_clause = ", ".join(f'"{col}"' for col in query_cols)
-    sql = (
-        f'SELECT {select_clause} FROM "{table}" '
-        f"WHERE {imei_expr} = ? ORDER BY \"{time_col}\""
-    )
-
-    normalized_imei = _normalized_imei_value(imei)
-    info_records: List[InfoRecord] = []
-    for row in conn.execute(sql, (normalized_imei,)):
-        dt = _parse_datetime(row[time_col])
-        if dt is None:
-            continue
-        raw_network = _safe_int(row[network_col])
-        network_label = NETWORK_TYPE_MAP.get(raw_network, "Desconocida")
-        csq = _safe_float(row[csq_col]) if csq_col else None
-        csq_ber = _safe_int(row[ber_col]) if ber_col else None
-        operator_value = "Desconocido"
-        if operator_col:
-            raw_operator = row[operator_col]
-            if raw_operator not in (None, ""):
-                operator_value = str(raw_operator).strip() or "Desconocido"
-        if operator_value in ("", "Desconocido"):
-            mcc_value = _safe_int(row[mcc_col]) if mcc_col else None
-            mnc_value = _safe_int(row[mnc_col]) if mnc_col else None
-            normalized = _normalize_operator(mcc_value, mnc_value)
-            if normalized != "Desconocido" or operator_value == "":
-                operator_value = normalized
-        info_records.append(
-            InfoRecord(
-                imei=imei,
-                send_time=dt,
-                network_label=network_label,
-                raw_network_value=raw_network,
-                csq=csq,
-                csq_ber=csq_ber,
-                operator=operator_value or "Desconocido",
-            )
-        )
-    conn.close()
-    return info_records
-
-
-# Sincronización -------------------------------------------------------------
-
-
-def _associate_info(points: List[LocationPoint], infos: List[InfoRecord]) -> None:
-    if not points or not infos:
-        return
-    infos_sorted = sorted(infos, key=lambda r: r.send_time)
-    info_times = [record.send_time for record in infos_sorted]
-    for point in sorted(points, key=lambda p: p.send_time):
-        index = bisect_left(info_times, point.send_time)
-        candidates: List[InfoRecord] = []
-        if 0 <= index < len(infos_sorted):
-            candidates.append(infos_sorted[index])
-        if index > 0:
-            candidates.append(infos_sorted[index - 1])
-
-        chosen: Optional[InfoRecord] = None
-        best_delta = float("inf")
-        for candidate in candidates:
-            delta = abs((candidate.send_time - point.send_time).total_seconds())
-            if delta > _ASSOCIATION_MAX_DELTA_SECONDS:
-                continue
-            if chosen is None or delta < best_delta:
-                chosen = candidate
-                best_delta = delta
-            elif delta == best_delta:
-                if chosen.send_time > point.send_time >= candidate.send_time:
-                    chosen = candidate
-
-        if chosen is None:
-            continue
-
-        point.network_label = chosen.network_label
-        point.csq = chosen.csq
-        point.csq_ber = chosen.csq_ber
-        quality, dbm = _classify_signal(
-            chosen.network_label, chosen.csq, chosen.csq_ber
-        )
-        point.signal_quality = quality
-        point.signal_dbm = dbm
-        if chosen.operator and chosen.operator not in {"", "Desconocido"}:
-            point.operator = chosen.operator
-
-
-# Filtros --------------------------------------------------------------------
-
-
-def _filter_points(
-    points: List[LocationPoint],
-    day: Optional[str] = None,
-    report_types: Optional[Sequence[str]] = None,
-    operators: Optional[Sequence[str]] = None,
-    networks: Optional[Sequence[str]] = None,
-) -> List[LocationPoint]:
-    """Filtra puntos aplicando prioridad Día → Tipo → Operador/Tecnología."""
-
-    normalized_ops = (
-        {op.strip().lower() for op in operators if op is not None}
-        if operators
-        else None
-    )
-    normalized_networks = (
-        {nt.strip().lower() for nt in networks if nt is not None}
-        if networks
-        else None
-    )
-    normalized_reports = (
-        {rp.strip().lower() for rp in report_types if rp is not None}
-        if report_types
-        else None
-    )
-
-    day_value: Optional[datetime] = None
-    if day:
-        day_clean = day.strip()
-        if day_clean.lower() not in {"all", "todos"}:
-            try:
-                day_value = datetime.strptime(day_clean, "%Y-%m-%d")
-            except ValueError as exc:  # pragma: no cover - validación de CLI
-                raise ValueError("El día debe tener formato YYYY-MM-DD") from exc
-
-    if day_value is None:
-        base_points = list(points)
-    else:
-        base_points = [
-            point for point in points if point.send_time.date() == day_value.date()
-        ]
-
-    if normalized_reports and "all" not in normalized_reports and "ambos" not in normalized_reports:
-        base_points = [
-            point
-            for point in base_points
-            if (point.report_kind or "").lower() in normalized_reports
-        ]
-
-    operator_set = (
-        None if not normalized_ops or "all" in normalized_ops else normalized_ops
-    )
-    network_set = (
-        None if not normalized_networks or "all" in normalized_networks else normalized_networks
-    )
-
-    result: List[LocationPoint] = []
-    for point in base_points:
-        if operator_set and (point.operator or "").lower() not in operator_set:
-            continue
-        if network_set and (point.network_label or "").lower() not in network_set:
-            continue
-        result.append(point)
-    return result
-
-
-# Render del mapa ------------------------------------------------------------
-
-
-def _ensure_output_path(path: Path) -> None:
-    if not path.parent.exists():
-        path.parent.mkdir(parents=True, exist_ok=True)
-
-
-def _point_to_tooltip(point: LocationPoint) -> str:
-    parts = [
-        f"IMEI: {point.imei}",
-        f"Reporte: {point.source.upper()}",
-        f"Tipo de reporte: {point.report_kind}",
-        f"Fecha envío: {point.send_time.strftime('%Y-%m-%d %H:%M:%S')}",
-        f"Coordenadas: {point.lat:.5f}, {point.lon:.5f}",
-        f"Operador: {point.operator}",
-        f"Tecnología: {point.network_label}",
-        f"Calidad de señal: {point.signal_quality}",
-    ]
-    if point.signal_dbm is not None:
-        parts.append(f"Nivel: {point.signal_dbm:.1f} dBm")
-    if point.csq is not None:
-        parts.append(f"CSQ: {point.csq}")
-    if point.csq_ber is not None:
-        parts.append(f"BER: {point.csq_ber}")
-    return "<br>".join(parts)
-
-
-class OperatorLegend(MacroElement):
-    def __init__(self, colors: Dict[str, str]):
-        super().__init__()
-        entries = []
-        for operator in sorted(
-            key for key in colors.keys() if key.lower() != "desconocido"
-        ):
-            color = colors.get(operator)
-            if not color:
-                continue
-            entries.append(
-                f'<div style="display:flex; align-items:center; margin-bottom:4px;">'
-                f'<span style="background:{color}; width:12px; height:12px; display:inline-block; '
-                f'margin-right:6px; border:1px solid #333;"></span>{operator}</div>'
-            )
-        entries_html = "".join(entries)
-        self._template = Template(
-            f"""
-            {{% macro html(this, kwargs) %}}
-            <div style="position: fixed; bottom: 40px; left: 40px; z-index: 9999; background-color: white;
-                        border: 1px solid #bbb; padding: 8px 12px; box-shadow: 0 2px 6px rgba(0,0,0,0.3);
-                        border-radius: 4px; font-size: 13px;">
-                <div style="font-weight: bold; margin-bottom: 6px;">Operadores</div>
-                {entries_html}
-            </div>
-            {{% endmacro %}}
-            """
-        )
-
-
-class FilterPanel(MacroElement):
-    """Panel de filtros jerárquicos Día → Tipo → Operador/Tecnología."""
-
-    def __init__(
-        self,
-        *,
-        points_data: List[dict],
-        day_options: List[str],
-        report_options: List[str],
-        operator_options: List[str],
-        network_options: List[str],
-        operator_colors: Dict[str, str],
-        initial_day: str,
-    ) -> None:
-        if Template is None:  # pragma: no cover - dependencia opcional
-            raise RuntimeError(
-                "jinja2 es requerida para generar el panel de filtros interactivo"
-            )
-        super().__init__()
-        self._name = "FilterPanel"
-        # Guardamos las estructuras Python originales para que Jinja
-        # se encargue de serializarlas correctamente mediante ``tojson``.
-        self.points_payload = points_data
-        self.operator_colors_payload = operator_colors
-        self.day_options = day_options
-        self.report_options = report_options
-        self.operator_options = operator_options
-        self.network_options = network_options
-        self.initial_day = initial_day
-        self._template = Template(
-            """
-            {% macro html(this, kwargs) %}
-            <div id="{{ this.get_name() }}" class="filter-panel" data-filter-panel="interactive-filters"
-                 style="position: fixed; top: 20px; left: 20px; z-index: 9999; background-color: white;"
-                 >
-                <div style="border: 1px solid #bbb; padding: 12px 14px; box-shadow: 0 2px 6px rgba(0,0,0,0.3); border-radius: 6px; width: 220px;">
-                    <div style="font-weight: bold; margin-bottom: 8px; font-size: 14px;">Filtros</div>
-                    <label for="{{ this.get_name() }}_day" style="display:block; font-weight:bold; margin-bottom:4px;">Día</label>
-                    <select id="{{ this.get_name() }}_day" style="width:100%; margin-bottom:10px; padding:4px;">
-                        <option value="All" {% if this.initial_day == "All" %}selected{% endif %}>Todos</option>
-                        {% for day in this.day_options %}
-                        <option value="{{ day }}" {% if day == this.initial_day %}selected{% endif %}>{{ day }}</option>
-                        {% endfor %}
-                    </select>
-                    <label for="{{ this.get_name() }}_report" style="display:block; font-weight:bold; margin-bottom:4px;">Tipo de reporte</label>
-                    <select id="{{ this.get_name() }}_report" style="width:100%; margin-bottom:10px; padding:4px;">
-                        <option value="AMBOS" selected>AMBOS</option>
-                        <option value="BUFFER">BUFFER</option>
-                        <option value="RESP">RESP</option>
-                    </select>
-                    <label for="{{ this.get_name() }}_operator" style="display:block; font-weight:bold; margin-bottom:4px;">Operador</label>
-                    <select id="{{ this.get_name() }}_operator" style="width:100%; margin-bottom:10px; padding:4px;">
-                        <option value="All" selected>Todos</option>
-                        {% for operator in this.operator_options %}
-                        <option value="{{ operator }}">{{ operator }}</option>
-                        {% endfor %}
-                    </select>
-                    <label for="{{ this.get_name() }}_network" style="display:block; font-weight:bold; margin-bottom:4px;">Tecnología</label>
-                    <select id="{{ this.get_name() }}_network" style="width:100%; padding:4px;">
-                        <option value="All" selected>Todos</option>
-                        {% for network in this.network_options %}
-                        <option value="{{ network }}">{{ network }}</option>
-                        {% endfor %}
-                    </select>
-                </div>
-            </div>
-            {% endmacro %}
-
-            {% macro script(this, kwargs) %}
-            (function(){
-              // ------------------ utilidades para esperar Folium ------------------
-              function _findFoliumMapKey(){
-                for (var k in window){
-                  if (Object.prototype.hasOwnProperty.call(window,k) &&
-                      /^map_[a-f0-9]+$/i.test(k) &&
-                      window[k] && typeof window[k].fitBounds === "function"){
-                    return k;
-                  }
-                }
-                return null;
-              }
-              function _findFoliumFigureKey(){
-                for (var k in window){
-                  if (Object.prototype.hasOwnProperty.call(window,k) &&
-                      /^figure_[a-f0-9]+$/i.test(k) && window[k]){
-                    return k;
-                  }
-                }
-                return null;
-              }
-
-              function _boot(){
-                console.debug("[FilterPanel] boot");
-
-                if (document.querySelector('script[src^="data:application/json;base64"]')) {
-                  console.error(`[FilterPanel] Detectado <script src="data:application/json;base64,…"> en el HTML. Esto no lo genera esta versión del código.`);
-                }
-
-                var figKey = _findFoliumFigureKey();
-                var mapKey = _findFoliumMapKey();
-                if (!figKey || !mapKey){
-                  // Folium todavía no definió los objetos → reintenta pronto
-                  return setTimeout(_boot, 40);
-                }
-                var mapObj = window[mapKey];
-
-                // ------------------ datos y estado ------------------
-                // Jinja serializa ``points_payload`` a JSON válido.
-                let pointsData;
-                try {
-                  pointsData = {{ this.points_payload | tojson }};
-                  if (!Array.isArray(pointsData)) { pointsData = []; }
-                  console.debug("[FilterPanel] total points:", pointsData.length);
-                } catch (e){
-                  console.error("[FilterPanel] error parsing points:", e);
-                  pointsData = [];
-                }
-
-                // Exponer a window para depuración desde la consola
-                window.__pointsData = pointsData;
-
-                // Opciones iniciales (ya renderizadas por el HTML/Jinja)
-                var $panel = document.querySelector('[data-filter-panel="interactive-filters"]');
-                var $day      = $panel.querySelector('#{{ this.get_name() }}_day');
-                var $report   = $panel.querySelector('#{{ this.get_name() }}_report');
-                var $operator = $panel.querySelector('#{{ this.get_name() }}_operator');
-                var $network  = $panel.querySelector('#{{ this.get_name() }}_network');
-
-                var trackLayer = window.trackLayer || L.layerGroup().addTo(mapObj);
-                var markerLayer = window.markerLayer || L.layerGroup().addTo(mapObj);
-
-                function _colorForOperator(op){
-                  var table = {{ this.operator_colors_payload | tojson }};
-                  return table[op] || "#7f7f7f";
-                }
-
-                function renderAll(){
-                  // 1) Día (prioritario)
-                  var day = ($day.value || "All").toLowerCase();
-                  var byDay = pointsData.filter(p => {
-                    if (day === "all" || day === "todos") return true;
-                    return (p.day || p.day_iso || "").toLowerCase() === day;
-                  });
-                  console.debug("[FilterPanel] after day:", byDay.length);
-
-                  // 2) Tipo de reporte
-                  var report = ($report.value || "AMBOS").toLowerCase();
-                  var byType = byDay.filter(p => {
-                    if (report === "ambos" || report === "all") return true;
-                    return (p.report || "").toLowerCase() === report;
-                  });
-                  console.debug("[FilterPanel] after report:", byType.length);
-
-                  // 3) Operador
-                  var op = ($operator.value || "All").toLowerCase();
-                  var byOp = byType.filter(p => {
-                    if (op === "all" || op === "todos") return true;
-                    return (p.operator || "Desconocido").toLowerCase() === op;
-                  });
-                  console.debug("[FilterPanel] after operator:", byOp.length);
-
-                  // 4) Tecnología
-                  var net = ($network.value || "All").toLowerCase();
-                  var final = byOp.filter(p => {
-                    if (net === "all" || net === "todos") return true;
-                    return (p.network || p.network_label || "Desconocida").toLowerCase() === net;
-                  });
-                  console.debug("[FilterPanel] after tech:", final.length);
-
-                  console.debug("[FilterPanel] final filtered:", final.length);
-
-                  // Repintado
-                  trackLayer.clearLayers();
-                  markerLayer.clearLayers();
-                  if (final.length === 0){
-                    return final;
-                  }
-
-                  // Markers y polilínea por operador (colores por operador)
-                  // Orden temporal
-                  final.sort((a,b)=> (a.timestamp || a.date || "").localeCompare(b.timestamp || b.date || ""));
-                  // markers
-                  final.forEach(p => {
-                    var color = _colorForOperator(p.operator || "Desconocido");
-                    L.circleMarker([p.lat, p.lon], {
-                      radius: 5, weight: 2, opacity: 1, fillOpacity: 0.7, color: color
-                    }).bindTooltip(p.tooltip || "").addTo(markerLayer);
-                  });
-
-                  // polilínea única (si quieres por operador, agrupar por p.operator)
-                  var latlngs = final.map(p => [p.lat, p.lon]);
-                  L.polyline(latlngs, {weight: 3, opacity: 0.8}).addTo(trackLayer);
-
-                  // Ajuste de vista
-                  if (latlngs.length === 1){
-                    mapObj.setView(latlngs[0], 13);
-                  } else {
-                    mapObj.fitBounds(latlngs, {padding:[30,30]});
-                  }
-
-                  return final;
-                }
-
-                // Exponer para depurar
-                window.__applyFilters = renderAll;
-
-                function setFilters(newFilters){
-                  newFilters = newFilters || {};
-
-                  function _assignIfPresent($select, key){
-                    if (!$select) { return; }
-                    if (!Object.prototype.hasOwnProperty.call(newFilters, key)) { return; }
-                    var value = newFilters[key];
-                    if (value === undefined || value === null) { return; }
-                    var stringValue = String(value);
-                    var options = Array.from($select.options || []);
-                    var match = options.find(function(opt){
-                      return String(opt.value).toLowerCase() === stringValue.toLowerCase();
-                    });
-                    if (match){
-                      $select.value = match.value;
-                    }
-                  }
-
-                  _assignIfPresent($day, 'day');
-                  _assignIfPresent($report, 'report');
-                  _assignIfPresent($operator, 'operator');
-                  _assignIfPresent($network, 'network');
-
-                  return renderAll();
-                }
-
-                function _exposeDebugHooks(){
-                  try {
-                    window.trackLayer  = window.trackLayer  || trackLayer  || L.layerGroup().addTo(mapObj);
-                    window.markerLayer = window.markerLayer || markerLayer || L.layerGroup().addTo(mapObj);
-
-                    window.__fp = {
-                      map: mapObj,
-                      data: pointsData,
-                      layers: {
-                        trackLayer:  window.trackLayer,
-                        markerLayer: window.markerLayer
-                      },
-                      renderAll,    // función que pinta todo
-                      setFilters    // función que cambia filtros programáticamente
-                    };
-
-                    console.debug('[FilterPanel] debug hooks listos', window.__fp);
-                  } catch(e) {
-                    console.error('[FilterPanel] no pude exponer hooks', e);
-                  }
-                }
-
-                _exposeDebugHooks();
-
-                function _onChange(){ renderAll(); }
-
-                $day.addEventListener('change', _onChange);
-                $report.addEventListener('change', _onChange);
-                $operator.addEventListener('change', _onChange);
-                $network.addEventListener('change', _onChange);
-
-                // Primer pintado
-                renderAll();
-              }
-
-              if (document.readyState === "loading"){
-                document.addEventListener("DOMContentLoaded", _boot);
-              } else {
-                _boot();
-              }
-            })();
-            {% endmacro %}
-
-            """
-        )
-
-
-def render_interactive_map(
-    points: List[LocationPoint],
-    output_html: Path,
-    *,
-    tiles: str = "OpenStreetMap",
-) -> None:
-    _require_folium()
-    if not points:
-        raise ValueError("No hay puntos para representar en el mapa")
-
-    points_sorted = sorted(points, key=lambda p: p.send_time)
-    center_lat = points_sorted[0].lat
-    center_lon = points_sorted[0].lon
-    fmap = Map(location=(center_lat, center_lon), zoom_start=13, tiles=tiles)
-    days = sorted({p.send_time.date().isoformat() for p in points_sorted})
-    report_kinds = sorted({(p.report_kind or "RESP") for p in points_sorted})
-    operators = sorted({(p.operator or "Desconocido") for p in points_sorted})
-    networks = sorted({(p.network_label or "Desconocida") for p in points_sorted})
-
-    points_payload = [
-        {
-            "lat": point.lat,
-            "lon": point.lon,
-            "day": point.day_iso or point.send_time.date().isoformat(),
-            "report": point.report_kind,
-            "operator": point.operator or "Desconocido",
-            "network": point.network_label or "Desconocida",
-            "signal_quality": point.signal_quality or "Desconocida",
-            "tooltip": _point_to_tooltip(point),
-            "timestamp": point.send_time.isoformat(),
-        }
-        for point in points_sorted
-    ]
-
-    initial_day = "All"
-
-    fmap.get_root().add_child(
-        FilterPanel(
-            points_data=points_payload,
-            day_options=days,
-            report_options=report_kinds,
-            operator_options=operators,
-            network_options=networks,
-            operator_colors=OPERATOR_COLORS,
-            initial_day=initial_day,
-        )
-    )
-
-    fmap.get_root().add_child(OperatorLegend(OPERATOR_COLORS))
-    fmap.fit_bounds([[p.lat, p.lon] for p in points_sorted])
-
-    _ensure_output_path(output_html)
-    fmap.save(str(output_html))
-
-
-# API pública ----------------------------------------------------------------
-
-
-def build_points(
+def ensure_map_databases(
     *,
     model: str,
-    imei: str,
-    base_dir: Path,
+    base_dir: Path | str = Path("bases_sqlite"),
     reports: Optional[Sequence[str]] = None,
-) -> List[LocationPoint]:
+    strict: bool = False,
+) -> Dict[str, Path]:
+    """Garantiza que existan las bases enriquecidas para los reportes solicitados.
+
+    Retorna un diccionario ``{reporte: ruta}`` con las bases _map actualizadas.
+    Si ``strict`` es ``False`` (por defecto) se omiten los reportes cuyo origen
+    no esté disponible y se emite una advertencia. Cuando es ``True`` la
+    función propaga la excepción ``FileNotFoundError`` correspondiente.
+    """
+
     model_clean = model.strip().lower()
     if not model_clean:
         raise ValueError("El modelo no puede estar vacío")
 
-    # Mantén el comportamiento actual: por defecto solo GTERI.
-    # (Si más adelante quieres soportar GTFRI por defecto, usa: ["gteri", "gtfri"])
-    reports_to_use = [r.lower() for r in (reports or ["gteri"])]
+    base_path = Path(base_dir)
+    report_names: Iterable[str]
+    if reports is None:
+        report_names = _DEFAULT_REPORTS
+    else:
+        report_names = [_normalize_report(name) for name in reports]
 
-    all_points: List[LocationPoint] = []
-    searched_paths: List[Path] = []
-    for report in reports_to_use:
-        map_path = base_dir / f"{report}_{model_clean}_map.db"
+    results: Dict[str, Path] = {}
+    missing: list[str] = []
 
-        # 1) Si ya existe la base enriquecida *_map.db, leerla directamente.
-        if map_path.exists():
-            searched_paths.append(map_path)
-            points = _load_locations_from_db(map_path, report, model_clean, imei)
-            all_points.extend(points)
-            continue
-
-        # 2) Si no existe, intenta generar/ubicar la ruta con ensure_enriched_database
+    for report in report_names:
         try:
-            enriched_path = ensure_enriched_database(
-                report=report,
-                model=model_clean,
-                base_dir=base_dir,
-                imei=imei,
+            results[report] = ensure_enriched_database(
+                report=report, model=model_clean, base_dir=base_path
             )
-            searched_paths.append(enriched_path)
-            points = _load_locations_from_db(enriched_path, report, model_clean, imei)
-            all_points.extend(points)
-        except FileNotFoundError:
-            # Registrar la ruta buscada para un mensaje de error claro más adelante.
-            searched_paths.append(map_path)
-            # Continuar con el siguiente reporte sin abortar.
-            pass
+        except FileNotFoundError as exc:
+            if strict:
+                raise
+            warnings.warn(
+                (
+                    f"No se encontró la base origen para el reporte '{report}' "
+                    f"del modelo '{model_clean}': {exc}"
+                ),
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            missing.append(report)
 
-    if not all_points:
-        existing_paths = list({path: None for path in searched_paths if path.exists()}.keys())
-        if existing_paths:
-            bases_detalle = ", ".join(path.name for path in existing_paths)
+    if not results:
+        if missing:
+            missing_list = ", ".join(sorted(missing))
             raise FileNotFoundError(
-                "No se encontraron registros de recorrido para el IMEI "
-                f"{imei} en las bases consultadas ({bases_detalle})."
+                "No se encontraron bases disponibles para los reportes solicitados "
+                f"({missing_list})."
             )
-
-        all_candidates = list({path: None for path in searched_paths}.keys())
-        bases_detalle = ", ".join(path.name for path in all_candidates) or "(ninguna)"
         raise FileNotFoundError(
-            "No se encontraron bases de datos de recorrido para el modelo "
-            f"'{model_clean}'. Se buscaron: {bases_detalle}."
+            "No se pudieron generar bases enriquecidas con los parámetros dados"
         )
 
-    info_candidates = [
-        base_dir / f"gtinf_{model_clean}_map.db",
-        base_dir / f"gtinf_{model_clean}.db",
-    ]
-    info_path = next((path for path in info_candidates if path.exists()), info_candidates[0])
-    info_records = _load_gtinf_records(info_path, model_clean, imei)
-    if info_records:
-        _associate_info(all_points, info_records)
-
-    return sorted(all_points, key=lambda p: p.send_time)
-
-
-def generate_map(
-    *,
-    model: str,
-    imei: str,
-    base_dir: Path | str = Path("bases_sqlite"),
-    output_dir: Path | str = Path("."),
-    day: Optional[str] = None,
-    report_types: Optional[Sequence[str]] = None,
-    operators: Optional[Sequence[str]] = None,
-    networks: Optional[Sequence[str]] = None,
-    reports: Optional[Sequence[str]] = None,
-    tiles: str = "OpenStreetMap",
-) -> Path:
-    base_path = Path(base_dir)
-    output_path = Path(output_dir)
-
-    points = build_points(model=model, imei=imei, base_dir=base_path, reports=reports)
-    filtered = _filter_points(
-        points,
-        day=day,
-        report_types=report_types,
-        operators=operators,
-        networks=networks,
-    )
-    if not filtered:
-        raise ValueError("Los filtros aplicados no devolvieron puntos para el mapa")
-
-    html_name = f"mapa_{model.lower()}_{imei}.html"
-    output_file = output_path / html_name
-    render_interactive_map(filtered, output_file, tiles=tiles)
-    return output_file
-
-
-# CLI ------------------------------------------------------------------------
+    return results
 
 
 def _parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Genera un mapa interactivo por IMEI utilizando las bases gteri_map y gtinf_map",
+        description=(
+            "Genera o actualiza las bases SQLite enriquecidas (gteri/gtfri) "
+            "cruzadas con GTINF para un modelo e IMEIs dados."
+        )
     )
     parser.add_argument("--model", required=True, help="Modelo del equipo (ej. gv350ceu)")
-    parser.add_argument("--imei", required=True, help="IMEI a consultar")
     parser.add_argument(
         "--db-dir",
         default="bases_sqlite",
-        help="Directorio que contiene los archivos SQLite (por defecto bases_sqlite)",
-    )
-    parser.add_argument(
-        "--out-dir",
-        default=".",
-        help="Directorio donde se guardará el mapa generado",
-    )
-    parser.add_argument(
-        "--day",
-        help="Filtra por fecha local (YYYY-MM-DD) usando send_time. Usa 'All' para no filtrar",
-    )
-    parser.add_argument(
-        "--operator",
-        dest="operators",
-        action="append",
-        help="Filtra por operador (puede repetirse). Usa 'All' para incluir todos",
-    )
-    parser.add_argument(
-        "--network",
-        dest="networks",
-        action="append",
-        help="Filtra por tecnología de red (2G, 3G, 4G). Usa 'All' para incluir todas",
+        help="Directorio que contiene las bases SQLite originales",
     )
     parser.add_argument(
         "--report",
         dest="reports",
         action="append",
-        choices=["gteri"],
-        help="Limita los reportes de posición a usar (solo se admite gteri)",
+        help="Reportes a procesar (por defecto gteri y gtfri)",
     )
     parser.add_argument(
-        "--tiles",
-        default="OpenStreetMap",
-        help="Proveedor de tiles para Folium",
+        "--strict",
+        action="store_true",
+        help="Falla si alguno de los reportes solicitados no está disponible",
     )
     return parser.parse_args(argv)
 
 
 def main(argv: Optional[Sequence[str]] = None) -> None:
     args = _parse_args(argv)
-    output_path = generate_map(
-        model=args.model,
-        imei=args.imei,
-        base_dir=Path(args.db_dir),
-        output_dir=Path(args.out_dir),
-        day=args.day,
-        operators=args.operators,
-        networks=args.networks,
-        reports=args.reports,
-        tiles=args.tiles,
-    )
-    print(f"Mapa generado en: {output_path}")
+    try:
+        results = ensure_map_databases(
+            model=args.model,
+            base_dir=Path(args.db_dir),
+            reports=args.reports,
+            strict=args.strict,
+        )
+    except FileNotFoundError as exc:  # pragma: no cover - errores de ejecución
+        raise SystemExit(str(exc)) from exc
+
+    for report, path in sorted(results.items()):
+        print(f"[{report}] Base enriquecida lista en: {path}")
+
+
+__all__ = ["ensure_map_databases", "main"]
 
 
 if __name__ == "__main__":  # pragma: no cover - punto de entrada CLI


### PR DESCRIPTION
## Summary
- simplify `viz/mapa_recorridos.py` into a CLI that only ensures the enriched `gteri/gtfri` SQLite databases
- add tests for the new database-maintenance workflow and update the helper script wording
- refresh the README to describe the database-focused process instead of HTML/GeoJSON output

## Testing
- pytest *(fails: numerous existing parser/schema assertions unrelated to the new database workflow)*

------
https://chatgpt.com/codex/tasks/task_e_68fa432663c08333bc337648b0f9dac8