### PR TITLE
Fix HDOP tolerance for GV310LAU GTERI frames

### DIFF
--- a/queclink/parser.py
+++ b/queclink/parser.py
@@ -427,7 +427,19 @@ def _should_force_parse(
     else:
         pattern = r"-?\d+(?:\.\d+)?"
 
-    return re.fullmatch(pattern, text) is not None
+    if re.fullmatch(pattern, text) is None:
+        return False
+
+    candidate: object
+    try:
+        candidate = int(text) if name == "sats_in_use" else float(text)
+    except ValueError:
+        return False
+
+    if not _value_within_limits(field, candidate):
+        return False
+
+    return True
 
 
 def _parse_field(

--- a/tests/gv310lau/test_gteri_spec_parser.py
+++ b/tests/gv310lau/test_gteri_spec_parser.py
@@ -8,6 +8,12 @@ RAW_WITH_UNMASKED_DOPS = (
     "0000015:21:09,,,,100,220100,0,0,20251017000001,3111$"
 )
 
+RAW_WITHOUT_DOPS = (
+    "+RESP:GTERI,6E0C03,868589060707695,GV310LAU,00000002,12797,10,1,1,0.0,348,479.8," \
+    "-70.775486,-33.431415,20251023201230,0730,0001,333C,00B24D03,00,17558.1,0001138:26:28,,,,100,110000," \
+    "0,0,20251023201458,A4C5$"
+)
+
 
 def test_parse_line_handles_unmasked_dops_gv310lau():
     data = parse_line(RAW_WITH_UNMASKED_DOPS)
@@ -21,3 +27,12 @@ def test_parse_line_handles_unmasked_dops_gv310lau():
     assert data["uart_device_type"] == 0
     assert data["send_time"] == "20251017000001"
     assert data["count_hex"] == "3111"
+
+
+def test_parse_line_skips_forced_dops_outside_range_gv310lau():
+    data = parse_line(RAW_WITHOUT_DOPS)
+
+    assert "hdop" not in data or data["hdop"] is None
+    assert data["mileage_km"] == pytest.approx(17558.1)
+    assert data["hour_meter"] == "0001138:26:28"
+    assert data["backup_battery_pct"] == 100


### PR DESCRIPTION
## Summary
- guard the tolerance that forces unmasked sats/dop fields so values outside their allowed ranges are ignored
- add a GV310LAU regression test covering GTERI frames without DOP fields to keep mileage parsing aligned

## Testing
- pytest tests/gv310lau/test_gteri_spec_parser.py

------
https://chatgpt.com/codex/tasks/task_e_68fa943b211c8333838546e25c3772b4