### PR TITLE
Handle GV75LAU GTFRI blank ext power field

### DIFF
--- a/spec/gv75lau/gtfri.yml
+++ b/spec/gv75lau/gtfri.yml
@@ -27,6 +27,13 @@ schema:
     - name: body
       fields:
         # Report ID / Report Type: 1 byte en HEX representado por 2 ASCII. X=ID, Y=Type
+        -
+          name: ext_power_mv
+          type: int
+          min: 1000
+          max: 900000
+          optional: true
+          comment: "External Power Voltage (mV); algunos firmware lo envían antes de <report_id_type> (>=1V para diferenciarlo)"
         - { name: report_id_type, type: hex, length: 2, comment: "XY -> X=Report ID (1..5), Y=Report Type (0..6)" }
         - { name: number, type: int, min: 1, max: 2, comment: "Cantidad de posiciones GNSS en el reporte (1 o 2)" }
 
@@ -54,9 +61,6 @@ schema:
 
         # Kilometraje total (si <Report Composition Mask> bit 4 = 1)
         - { name: mileage_km, type: float, min: 0.0, max: 4294967.0, precision: 1, optional: true }
-
-        # Voltaje de alimentación externa (si AT+GTEPS <Sync with FRI> = 1)
-        - { name: ext_power_mv, type: int, min: 0, max: 900000, optional: true }
 
         # Hour Meter (si AT+GTHMC habilitado)
         - { name: hour_meter_count, type: string, pattern: "^[0-9]{5,7}:[0-9]{2}:[0-9]{2}$", optional: true }

--- a/tests/gv75lau/test_gtfri_parser.py
+++ b/tests/gv75lau/test_gtfri_parser.py
@@ -17,3 +17,16 @@ def test_gtfri_gv75lau_parse_line_resp_y_buff():
         assert data.get("model") == "GV75LAU"
         assert data.get("header") in {"+RESP:GT", "+BUFF:GT"}
         assert data.get("imei") == "866314060583471"
+
+
+def test_gtfri_gv75lau_optional_ext_power_before_report_id():
+    line = (
+        "+RESP:GTFRI,80200C0201,866314062233117,GV75LAU,,50,1,1,0.0,14,605.5,"
+        "-70.638090,-33.433986,20251104153233,0730,0003,9C50,DF0D,01,12,45300.0,,,,,100,210100,,,,20251104153234,0FD9$"
+    )
+
+    data = parse_line(line)
+
+    assert data.get("report_id_type") == "50"
+    assert data.get("number") == 1
+    assert data.get("ext_power_mv") is None


### PR DESCRIPTION
## Summary
- allow GV75LAU GTFRI specs to accept an optional external power slot before report_id_type
- ensure parser skips the slot when it only contains an empty value
- cover the new format with a unit test that exercises a real GV75LAU payload

## Testing
- pytest tests/gv75lau/test_gtfri_parser.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ddd36b85c8333a7613516164e89d7)