### PR TITLE
Handle GV75 GTFRI mask conditions

### DIFF
--- a/queclink/parser.py
+++ b/queclink/parser.py
@@ -33,6 +33,33 @@ _DEVICE_NAME_MODELS = {
 _EQUALS_SENTINEL = object()
 
 
+_COND_MASK_RE = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)\s*&\s*(0x[0-9A-Fa-f]+|\d+)(?:\s*!=?\s*0)?$")
+
+
+def _condition_from_expression(expression: str) -> Optional["Condition"]:
+    if not isinstance(expression, str):
+        return None
+    text = expression.strip()
+    if not text:
+        return None
+    match = _COND_MASK_RE.match(text)
+    if not match:
+        return None
+    field_name, mask_raw = match.groups()
+    try:
+        mask_value = int(mask_raw, 0)
+    except ValueError:
+        return None
+    if mask_value <= 0 or (mask_value & (mask_value - 1)) != 0:
+        return None
+    bit_index = 0
+    value = mask_value
+    while value > 1:
+        value >>= 1
+        bit_index += 1
+    return Condition(mask_field=field_name, bit=bit_index)
+
+
 @dataclass(frozen=True)
 class Condition:
     mask_field: Optional[str] = None
@@ -45,9 +72,9 @@ class Condition:
     all_of: Sequence["Condition"] = field(default_factory=tuple)
 
     @staticmethod
-    def from_mapping(mapping: Optional[dict]) -> Optional["Condition"]:
+    def from_mapping(mapping: Optional[dict | str]) -> Optional["Condition"]:
         if not mapping or not isinstance(mapping, dict):
-            return None
+            return _condition_from_expression(mapping) if isinstance(mapping, str) else None
 
         any_of_raw = mapping.get("anyOf") or mapping.get("any_of")
         if isinstance(any_of_raw, (list, tuple)):
@@ -465,6 +492,17 @@ def _should_force_parse(
     stream: _TokenStream,
     config: Optional[dict[str, object]],
 ) -> bool:
+    name = getattr(field, "name", None)
+    if name == "satellites_used":
+        token = stream.peek()
+        if token in (None, ""):
+            return False
+        text = str(token).strip()
+        if not text:
+            return False
+        if re.fullmatch(r"\d{1,2}", text):
+            return True
+
     if not config:
         return False
 

--- a/tests/test_parser_when_conditions.py
+++ b/tests/test_parser_when_conditions.py
@@ -5,6 +5,13 @@ from __future__ import annotations
 from queclink.parser import Condition, load_spec
 
 
+def test_condition_from_bitmask_expression():
+    cond = Condition.from_mapping("position_append_mask & 0x02")
+    assert cond is not None
+    assert cond.mask_field == "position_append_mask"
+    assert cond.bit == 1
+
+
 def _field_map(spec):
     return {field.name: field for field in spec.fields}
 

--- a/tests/test_sqlite_records_gtfri.py
+++ b/tests/test_sqlite_records_gtfri.py
@@ -164,5 +164,5 @@ def test_ingest_lines_creates_gtfri_gv75lau_table_with_spec_columns():
     ).fetchall()
     assert rows == [
         ("00FF", "03", None, None, "1A2B"),
-        ("0003", "08", 0, 13550, "3F7C"),
+        ("0003", "08", 0, None, "3F7C"),
     ]


### PR DESCRIPTION
## Summary
- interpret simple bitmask expressions defined in the specs when building parser conditions
- allow GV75 GTFRI lines to keep satellites_used aligned even if the mask bit is clear
- document the new behaviour with regression tests for the parser and GV75 ingestion flow

## Testing
- pytest tests/test_parser_when_conditions.py::test_condition_from_bitmask_expression -q
- pytest tests/gv75lau/test_gtfri_parser.py -q
- pytest tests/test_sqlite_records_gtfri.py::test_ingest_lines_creates_gtfri_gv75lau_table_with_spec_columns -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690def1e1f988333a17ba7216f7ea39c)