### PR TITLE
Adjust GV75LAU GTFRI tests for new spec fields

### DIFF
--- a/tests/gv75lau/test_gtfri_parser.py
+++ b/tests/gv75lau/test_gtfri_parser.py
@@ -4,8 +4,16 @@ from queclink.parser import parse_line
 
 
 RAW = [
-    "+RESP:GTFRI,80200C0100,866314060583471,GV75LAU,10,1,12,45.6,180,12.3,-70.650123,-33.437200,20251029091530,0460,0000,1A2B,00FF,03,12345.6,20251029091533,1A2B$",
-    "+BUFF:GTFRI,80200C0100,866314060583471,GV75LAU,11,1,8,0.0,0,0.0,-70.650100,-33.437100,20251029092000,0460,0000,1A2B,0003,08,0,13550,00012:35:07,20251029092002,3F7C$",
+    (
+        "+RESP:GTFRI,80200C0300,866314060583471,GV75LAU,10,1,12,45.6,180,12.3,"
+        "-70.650123,-33.437200,20251029091530,0460,0000,1A2B,00FF,03,12,3,12345.6,"
+        "00012:35:07,,,,85,221102,,,,20251029091533,1A2B$"
+    ),
+    (
+        "+BUFF:GTFRI,80200C0300,866314060583471,GV75LAU,11,1,8,0.0,0,0.0,"
+        "-70.650100,-33.437100,20251029092000,0460,0000,1A2B,0003,03,10,1,13550.0,"
+        "00012:35:07,,,,100,210100,,,,20251029092002,3F7C$"
+    ),
 ]
 
 
@@ -17,12 +25,17 @@ def test_gtfri_gv75lau_parse_line_resp_y_buff():
         assert data.get("model") == "GV75LAU"
         assert data.get("header") in {"+RESP:GT", "+BUFF:GT"}
         assert data.get("imei") == "866314060583471"
+        assert data.get("position_append_mask") == "03"
+        assert data.get("satellites_used") in {12, 10}
+        assert data.get("gnss_trigger_type") in {3, 1}
+        assert data.get("backup_battery_percentage") in {85, 100}
+        assert data.get("device_status") in {"221102", "210100"}
 
 
 def test_gtfri_gv75lau_optional_ext_power_before_report_id():
     line = (
         "+RESP:GTFRI,80200C0201,866314062233117,GV75LAU,,50,1,1,0.0,14,605.5,"
-        "-70.638090,-33.433986,20251104153233,0730,0003,9C50,DF0D,01,12,45300.0,,,,,100,210100,,,,20251104153234,0FD9$"
+        "-70.638090,-33.433986,20251104153233,0730,0003,9C50,DF0D,03,12,3,45300.0,,,,,100,210100,,,,20251104153234,0FD9$"
     )
 
     data = parse_line(line)
@@ -30,3 +43,7 @@ def test_gtfri_gv75lau_optional_ext_power_before_report_id():
     assert data.get("report_id_type") == "50"
     assert data.get("number") == 1
     assert data.get("ext_power_mv") is None
+    assert data.get("satellites_used") == 12
+    assert data.get("gnss_trigger_type") == 3
+    assert data.get("backup_battery_percentage") == 100
+    assert data.get("device_status") == "210100"

--- a/tests/test_sqlite_records_gtfri.py
+++ b/tests/test_sqlite_records_gtfri.py
@@ -37,12 +37,12 @@ GTFRI_GV350CEU_LINES = [
 
 
 GTFRI_GV75LAU_LINES = [
-    "+RESP:GTFRI,80200C0100,866314060583471,GV75LAU,10,1,12,45.6,180,12.3,"\
-    "-70.650123,-33.437200,20251029091530,0460,0000,1A2B,00FF,03,12345.6,"\
-    "20251029091533,1A2B$",
-    "+BUFF:GTFRI,80200C0100,866314060583471,GV75LAU,11,1,8,0.0,0,0.0,"\
-    "-70.650100,-33.437100,20251029092000,0460,0000,1A2B,0003,08,0,13550,"\
-    "00012:35:07,20251029092002,3F7C$",
+    "+RESP:GTFRI,80200C0300,866314060583471,GV75LAU,10,1,12,45.6,180,12.3,"\
+    "-70.650123,-33.437200,20251029091530,0460,0000,1A2B,00FF,03,12,3,12345.6,"\
+    "00012:35:07,,,,85,221102,,,,20251029091533,1A2B$",
+    "+BUFF:GTFRI,80200C0300,866314060583471,GV75LAU,11,1,8,0.0,0,0.0,"\
+    "-70.650100,-33.437100,20251029092000,0460,0000,1A2B,0003,03,10,1,13550.0,"\
+    "00012:35:07,,,,100,210100,,,,20251029092002,3F7C$",
 ]
 
 
@@ -160,9 +160,10 @@ def test_ingest_lines_creates_gtfri_gv75lau_table_with_spec_columns():
 
     rows = conn.execute(
         f'SELECT cell_id, position_append_mask, satellites_used, '
-        f'gnss_trigger_type, count_hex FROM "{table_name}" ORDER BY send_time'
+        f'gnss_trigger_type, mileage_km, backup_battery_percentage, '
+        f'device_status, count_hex FROM "{table_name}" ORDER BY send_time'
     ).fetchall()
     assert rows == [
-        ("00FF", "03", None, None, "1A2B"),
-        ("0003", "08", 0, None, "3F7C"),
+        ("00FF", "03", 12, 3, 12345.6, 85, "221102", "1A2B"),
+        ("0003", "03", 10, 1, 13550.0, 100, "210100", "3F7C"),
     ]


### PR DESCRIPTION
## Summary
- refresh the GV75LAU GTFRI samples to include the reserved slots, backup battery percentage, and device status from the updated spec
- extend the parser expectations to cover satellites, trigger type, and power-related fields for GV75LAU
- validate SQLite ingestion for the new GV75LAU GTFRI columns and values

## Testing
- pytest tests/gv75lau/test_gtfri_parser.py -q
- pytest tests/test_sqlite_records_gtfri.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e0a13e120833388466ae512955e7d)