### PR TITLE
Add GV75LAU support to GTFRI enriched map workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ las ubicaciones (`GTERI`/`GTFRI`) con la información de red proveniente de `GTI
 
 Las bases de datos GTERI / GTFRI y GTINF deben estar en la carpeta `bases_sqlite` las bases de datos
 deberían estar con los siguientes nombres `gteri_<modelo>.db`, `gtfri_<modelo>.db` o `gtinf_<modelo>.db`
-(ej: `gteri_gv310lau.db`).
+(ej: `gteri_gv310lau.db`). Para el equipo **GV75LAU** (que reporta recorridos vía `GTFRI`) asegúrate
+de contar con `gtfri_gv75lau.db` y `gtinf_gv75lau.db` (o sus variantes `_map.db` si ya fueron
+generadas). Actualmente se soportan los modelos GV310LAU, GV58LAU, GV75LAU y GV350CEU.
 
 El proceso agrega/actualiza las columnas `tecnologia_celular`, `calidad_senal`,
 `nivel_senal_dbm` y `operador`, rellenándolas con la mejor medición `GTINF` disponible para cada
@@ -77,6 +79,10 @@ Ejemplo de ejecución:
 
 ```bash
 py generate_map.py --model gv350ceu --db-dir bases_sqlite
+```
+
+```bash
+py generate_map.py --model gv75lau --db-dir bases_sqlite --report gtfri
 ```
 
 El comando anterior creará o actualizará las bases enriquecidas disponibles en `bases_sqlite`.

--- a/tests/viz/test_mapa_recorridos.py
+++ b/tests/viz/test_mapa_recorridos.py
@@ -111,3 +111,87 @@ def test_ensure_map_databases_strict_raises_on_missing(tmp_path: Path) -> None:
 
     with pytest.raises(FileNotFoundError):
         ensure_map_databases(model=model, base_dir=base_dir, reports=["gtfri"], strict=True)
+
+
+def _setup_gtfri_sources(tmp_path: Path) -> tuple[Path, str, str]:
+    base_dir = tmp_path
+    model = "gv75lau"
+    imei = "866314060583471"
+
+    gtfri_source = base_dir / f"gtfri_{model}.db"
+    conn = sqlite3.connect(gtfri_source)
+    table_name = f"gtfri_{model}"
+    conn.execute(
+        f"""
+        CREATE TABLE "{table_name}" (
+            imei TEXT,
+            gnss_utc_time TEXT,
+            latitude REAL,
+            longitude REAL,
+            header TEXT
+        )
+        """
+    )
+    conn.executemany(
+        f'INSERT INTO "{table_name}" (imei, gnss_utc_time, latitude, longitude, header) '
+        "VALUES (?, ?, ?, ?, ?)",
+        [
+            (imei, "20251029091530", -33.437200, -70.650123, "+RESP:GTFRI"),
+            (imei, "20251029092000", -33.437100, -70.650100, "+BUFF:GTFRI"),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    gtinf_source = base_dir / f"gtinf_{model}.db"
+    conn = sqlite3.connect(gtinf_source)
+    table_name = f"gtinf_{model}"
+    conn.execute(
+        f"""
+        CREATE TABLE "{table_name}" (
+            imei TEXT,
+            send_time TEXT,
+            network_type INTEGER,
+            csq REAL,
+            csq_ber INTEGER,
+            operador TEXT,
+            mcc INTEGER,
+            mnc INTEGER
+        )
+        """
+    )
+    conn.executemany(
+        f'INSERT INTO "{table_name}" (imei, send_time, network_type, csq, csq_ber, operador, mcc, mnc) '
+        'VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+        [
+            (imei, "20251029091530", 3, 160.0, None, "WOM", None, None),
+            (imei, "20251029092000", 2, 10.0, 6, "", 730, 3),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    return base_dir, model, imei
+
+
+def test_ensure_map_databases_enriches_gtfri_gv75lau(tmp_path: Path) -> None:
+    base_dir, model, _ = _setup_gtfri_sources(tmp_path)
+
+    results = ensure_map_databases(model=model, base_dir=base_dir, reports=["gtfri"])
+
+    assert set(results) == {"gtfri"}
+    db_path = results["gtfri"]
+    assert db_path.exists()
+
+    conn = sqlite3.connect(db_path)
+    rows = conn.execute(
+        f'SELECT gnss_utc_time, tecnologia_celular, calidad_senal, nivel_senal_dbm, operador '
+        f'FROM "gtfri_{model}" ORDER BY gnss_utc_time'
+    ).fetchall()
+    conn.close()
+
+    summary = [tuple(row) for row in rows]
+    assert summary == [
+        ("20251029091530", "4G", "Excelente", 20.0, "WOM"),
+        ("20251029092000", "3G", "Regular", -93.0, "Claro"),
+    ]


### PR DESCRIPTION
## Summary
- document the GV75LAU GTFRI/GTINF database requirements and usage flow in the README
- extend the enriched database test coverage to validate GV75LAU GTFRI + GTINF enrichment

## Testing
- pytest tests/viz/test_mapa_recorridos.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911d40dd1e48333950f2b71ae7c4c67)