### PR TITLE
Handle optional GTINF placeholders as null values

### DIFF
--- a/queclink/messages/gtinf.py
+++ b/queclink/messages/gtinf.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 from typing import Dict, List, Optional
 import re
 
-from ..parser import _split, detect_model_from_identifiers
-from ..specs.loader import get_spec_columns
+from ..parser import _split, detect_model_from_identifiers, load_spec
 
 _GTINF_HEADERS = {"+RESP:GTINF", "+BUFF:GTINF"}
 
@@ -43,14 +42,16 @@ def parse_gtinf(line: str, source: str = "RESP", device: Optional[str] = None) -
 
     model = model.strip().upper()
     try:
-        columns = get_spec_columns("GTINF", model)
-    except ValueError:
+        spec = load_spec(model, "GTINF")
+    except (ValueError, FileNotFoundError):
         fallback = reported_device_name.strip().upper()
         if fallback and fallback != model:
-            columns = get_spec_columns("GTINF", fallback)
+            spec = load_spec(fallback, "GTINF")
             model = fallback
         else:
             raise
+
+    columns = [field.name for field in spec.fields]
 
     # Reconstruir "header" y "message" de la spec a partir del primer token
     hm = _split_header_message(first)
@@ -64,8 +65,17 @@ def parse_gtinf(line: str, source: str = "RESP", device: Optional[str] = None) -
     values.append(hm["message"])
 
     iterator = iter(parts[1:])
-    for column in columns[2:]:
-        values.append(next(iterator, None))
+    for field in spec.fields[2:]:
+        raw_value = next(iterator, None)
+        if raw_value is None:
+            values.append(None)
+            continue
+
+        if raw_value == "" and (field.optional or getattr(field, "nullable", False)):
+            values.append(None)
+            continue
+
+        values.append(raw_value)
 
     homologated = dict(zip(columns, values))
     if reported_device_name:

--- a/tests/gv350ceu/test_gtinf_parser.py
+++ b/tests/gv350ceu/test_gtinf_parser.py
@@ -1,5 +1,6 @@
 import re
 from queclink.parser import parse_line
+from queclink.messages.gtinf import parse_gtinf
 from tests.common.assert_gtinf_shape import assert_gtinf_shape
 
 RAW = [
@@ -18,3 +19,10 @@ def test_gtinf_gv350ceu_basico():
         assert d["imei"] == shape["imei"]
         assert d["count_hex"] == shape["count_hex"]
         assert "send_time_iso" in d and len(d["send_time_iso"]) >= 19
+
+
+def test_gtinf_gv350ceu_reserved_fields_are_none():
+    data = parse_gtinf(RAW[0], device="GV350CEU")
+    assert "reserved1" in data and data["reserved1"] is None
+    assert "reserved2" in data and data["reserved2"] is None
+    assert "reserved3" in data and data["reserved3"] is None


### PR DESCRIPTION
## Summary
- load the GTINF YAML spec to map values so optional placeholders are aligned with the defined columns
- normalize empty optional GTINF fields to None to properly expose reserved slots
- cover the GV350CEU reserved fields scenario with an automated test

## Testing
- `pytest tests/gv350ceu/test_gtinf_parser.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911e721ad3c833382ca7d97e5fc43e2)