### PR TITLE
Add GV75LAU GTJDS ingestion and parser tests

### DIFF
--- a/tests/gv75lau/test_gtjds_parser.py
+++ b/tests/gv75lau/test_gtjds_parser.py
@@ -1,0 +1,67 @@
+"""Parser tests for GV75LAU +RESP/+BUFF:GTJDS messages."""
+
+from queclink.parser import parse_line
+
+
+RESP_SAMPLE = (
+    "+RESP:GTJDS,80200C0300,135790246811220,GV75LAU,1,3,0,4.3,92,70.0,"
+    "121.354335,31.222073,20230214013254,0460,0000,18d8,6141,05,1,220100,"
+    "20230214093254,11F0$"
+)
+
+
+BUFF_SAMPLE = (
+    "+BUFF:GTJDS,80200C0300,135790246811220,GV75LAU,2,3,0,0.0,0,0.0,-, -,"
+    "20230214013254,,,,,00,20230214013254,11F1$"
+)
+
+
+def test_parse_gtjds_resp_core_fields():
+    data = parse_line(RESP_SAMPLE)
+
+    assert data.get("header") == "+RESP:GTJDS"
+    assert data.get("message") == "GTJDS"
+    assert data.get("unique_id") == "135790246811220"
+    assert data.get("device_name") == "GV75LAU"
+
+    assert data.get("jamming_status") == 1
+    assert data.get("jamming_net") == 3
+    assert data.get("gnss_accuracy_level") == 0
+
+    assert data.get("mcc") == "0460"
+    assert data.get("mnc") == "0000"
+    assert data.get("lac_hex") == "18D8"
+    assert data.get("cell_id_hex") == "6141"
+
+    assert data.get("position_append_mask") == "05"
+    assert data.get("satellites_in_use") == 1
+    assert data.get("device_status") == "220100"
+
+    assert data.get("send_time") == "20230214093254"
+    assert data.get("count_number") == "11F0"
+    assert data.get("tail") == "$"
+
+
+def test_parse_gtjds_buff_handles_missing_values():
+    data = parse_line(BUFF_SAMPLE)
+
+    assert data.get("header") == "+BUFF:GTJDS"
+    assert data.get("message") == "GTJDS"
+    assert data.get("unique_id") == "135790246811220"
+
+    assert data.get("jamming_status") == 2
+    assert data.get("longitude_deg") is None
+    assert data.get("latitude_deg") is None
+
+    assert data.get("mcc") == ""
+    assert data.get("mnc") == ""
+    assert data.get("lac_hex") == ""
+    assert data.get("cell_id_hex") == ""
+
+    assert data.get("position_append_mask") == "00"
+    assert data.get("satellites_in_use") is None
+    assert data.get("device_status") is None
+
+    assert data.get("send_time") == "20230214013254"
+    assert data.get("count_number") == "11F1"
+    assert data.get("tail") == "$"

--- a/tests/test_sqlite_records_gtjds.py
+++ b/tests/test_sqlite_records_gtjds.py
@@ -1,4 +1,4 @@
-"""SQLite ingestion tests for GV310LAU GTJDS records."""
+"""SQLite ingestion tests for GTJDS records across supported models."""
 
 from src.ingestors.sqlite_records import (
     ensure_db,
@@ -89,5 +89,61 @@ def test_ingest_lines_creates_gtjds_gv310lau_table_with_spec_columns():
             "0001",
             "0C82",
             "00550412",
+        ),
+    ]
+
+
+GTJDS_GV75LAU_LINES = [
+    "+RESP:GTJDS,80200C0300,135790246811220,GV75LAU,1,3,0,4.3,92,70.0,121.354335,31.222073,20230214013254,0460,0000,18d8,6141,05,1,220100,20230214093254,11F0$",
+    "+BUFF:GTJDS,80200C0300,135790246811220,GV75LAU,2,3,0,0.0,0,0.0,-, -,20230214013254,,,,,00,20230214013254,11F1$",
+]
+
+
+def test_ingest_lines_creates_gtjds_gv75lau_table_with_spec_columns():
+    conn = ensure_db(":memory:")
+
+    inserted = ingest_lines(conn, GTJDS_GV75LAU_LINES, message="GTJDS")
+    assert inserted == len(GTJDS_GV75LAU_LINES)
+
+    spec = resolve_spec("GTJDS", "GV75LAU")
+    table_name = spec["spec"].table_name
+
+    cursor = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+        (table_name,),
+    )
+    assert cursor.fetchone() is not None
+
+    info = conn.execute(f'PRAGMA table_info("{table_name}")').fetchall()
+    columns = [row[1] for row in info]
+    expected_columns = [name for name, _ in spec_to_sql_columns(spec)]
+    assert columns == expected_columns
+
+    rows = conn.execute(
+        f'SELECT unique_id, jamming_status, jamming_net, position_append_mask, '
+        f'satellites_in_use, device_status, longitude_deg, latitude_deg '
+        f'FROM "{table_name}" ORDER BY send_time'
+    ).fetchall()
+
+    assert rows == [
+        (
+            "135790246811220",
+            2,
+            3,
+            "00",
+            None,
+            None,
+            None,
+            None,
+        ),
+        (
+            "135790246811220",
+            1,
+            3,
+            "05",
+            1,
+            "220100",
+            121.354335,
+            31.222073,
         ),
     ]


### PR DESCRIPTION
## Summary
- add parser coverage for GV75LAU +RESP/+BUFF GTJDS messages using the new spec
- ensure SQLite ingestion handles GTJDS records for GV75LAU without affecting existing models

## Testing
- pytest tests/gv75lau/test_gtjds_parser.py tests/test_sqlite_records_gtjds.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69137d24f7688333a68c48aa67714db7)