### PR TITLE
Handle GNSS trigger mask for GV37CAU GTFRI

### DIFF
--- a/queclink/parser.py
+++ b/queclink/parser.py
@@ -508,6 +508,11 @@ def _should_force_parse(
     if not config:
         return False
 
+    if name == "gnss_trigger_type":
+        token = stream.peek()
+        if token == "":
+            return True
+
     tolerated_raw = config.get("tolerate_unmasked_position_fields")
     if not tolerated_raw:
         return False

--- a/spec/gv37cau/gtfri.yml
+++ b/spec/gv37cau/gtfri.yml
@@ -72,10 +72,13 @@ schema:
           type: int
           min: 0
           max: 4
+          optional: true
           nullable: true
+          when: { mask: position_append_mask, bit: 1 }
           description: >
             Tipo de disparo del punto GNSS (0=Time, 1=Corner, 2=Distance, 3=Mileage, 4=Optimum).
-            Puede venir vacío si la función no está habilitada en ERI Mask.
+            Solo se incluye si el bit1 de la Position Append Mask está activo; si el bit está apagado, el
+            campo se omite por completo.
 
         # --- Contadores y entradas analógicas ---
         - { name: mileage_km, type: float, min: 0.0, max: 4294967.0, description: "Current Mileage, incluido en cada posición" }
@@ -110,6 +113,7 @@ masks:
     size_bits: 8
     bits:
       0: { field: sats_in_use, description: "Satellites in Use" }
+      1: { field: gnss_trigger_type, description: "GNSS Trigger Type (si bit1=1)" }
       # Bits 1-7 se dejan sin mapear en este esquema; reservados para futuras extensiones
       # (p.ej. RAT/Band data u otros campos controlados por AT+GTFRI/ERI).
 

--- a/tests/gv37cau/test_parser_gv37cau_reports.py
+++ b/tests/gv37cau/test_parser_gv37cau_reports.py
@@ -81,3 +81,17 @@ def test_parse_line_imei_only_detection(line, expected_report):
 
     assert parsed["report"] == expected_report
     assert parsed["model"] == "GV37CAU"
+
+
+def test_gtfri_position_append_mask_without_gnss_trigger():
+    line = (
+        "+RESP:GTFRI,8020220200,868487005333364,,,50,1,1,1.6,250,585.3,-70.638368,-33.434252,"
+        "20251117111630,0730,0001,333B,008D1203,01,0,56423.9,,,,,100,220100,,,,20251117111632,4315$"
+    )
+
+    parsed = parse_line(line)
+
+    assert parsed["position_append_mask"] == "01"
+    assert parsed["sats_in_use"] == 0
+    assert parsed.get("gnss_trigger_type") is None
+    assert parsed["backup_batt_pct"] == 100


### PR DESCRIPTION
## Summary
- make GNSS trigger parsing conditional on the GV37CAU position append mask and optional
- consume empty placeholders to keep fields aligned while skipping masked values
- add regression coverage for GV37CAU GTFRI frames without GNSS trigger data

## Testing
- python -m pytest tests/gv37cau/test_parser_gv37cau_reports.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b6dea19748333ad4993313320a056)