### PR TITLE
Actualizar homologación GTINF/GTERI y CLI de ingestión

### DIFF
--- a/queclink/ingestor_sqlite.py
+++ b/queclink/ingestor_sqlite.py
@@ -179,6 +179,10 @@ class SQLiteIngestor:
     def ensure_table(self, model: str, message: str, spec: Optional[Spec] = None) -> Sequence[FieldSpec]:
         spec = spec or load_spec(model, message)
         fields = spec.fields
+        table_field_names = (spec.config or {}).get("table_fields") if hasattr(spec, "config") else None
+        if table_field_names:
+            field_map = {field.name: field for field in fields}
+            fields = [field_map[name] for name in table_field_names if name in field_map]
         table = spec.table_name
         conn = self.connection
 

--- a/queclink/messages/gteri.py
+++ b/queclink/messages/gteri.py
@@ -615,6 +615,7 @@ def _parse_model_specific_default(fields: List[str], start_idx: int) -> Dict[str
     if cursor < len(remaining):
         peek = (remaining[cursor] or "").strip().upper()
         ble_bit_on = (eri_mask_value is not None) and ((eri_mask_value & ((1 << 8) | (1 << 12))) != 0)
+        ble_start = cursor
         if peek == "BLE":
             cursor += 1
             ble_block, cursor = _parse_ble_block(remaining, cursor)
@@ -624,6 +625,21 @@ def _parse_model_specific_default(fields: List[str], start_idx: int) -> Dict[str
             if ble_block:
                 cursor = cursor_candidate
             skip_empty_values()
+
+        if (not ble_block or (ble_block.get("accessory_number") in (None, 0))) and ble_bit_on:
+            for idx in range(0, len(remaining)):
+                candidate_block, candidate_cursor = _parse_ble_block(remaining, idx)
+                accessory_number = (candidate_block or {}).get("accessory_number") if candidate_block else None
+                items = (candidate_block or {}).get("items") if candidate_block else None
+                if not (accessory_number and items and 0 < accessory_number <= 25):
+                    continue
+                if len(items) != accessory_number:
+                    continue
+                has_mask = any((item or {}).get("append_mask") for item in items)
+                if has_mask:
+                    ble_block = candidate_block
+                    cursor = candidate_cursor
+                    break
     if ble_block:
         out["ble_block"] = ble_block
         out["ble_count"] = ble_block.get("accessory_number")

--- a/queclink/messages/gtinf.py
+++ b/queclink/messages/gtinf.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
-from typing import Dict, List, Optional
-import re
+from typing import Any, Dict, List, Optional
 
-from ..parser import _split, detect_model_from_identifiers, load_spec
+from ..parser import (
+    _split,
+    _tokenize,
+    detect_model_from_identifiers,
+    load_spec,
+    normalize_line_for_spec,
+)
 
-_GTINF_HEADERS = {"+RESP:GTINF", "+BUFF:GTINF"}
+_GTINF_HEADERS = {"+RESP:GTINF", "+BUFF:GTINF", "+RESP:GT", "+BUFF:GT"}
 
 def _split_header_message(first_token: str) -> Optional[Dict[str, str]]:
     # first_token es "+RESP:GTINF" o "+BUFF:GTINF"
@@ -32,9 +37,15 @@ def parse_gtinf(line: str, source: str = "RESP", device: Optional[str] = None) -
     if first not in _GTINF_HEADERS:
         return {}
 
-    # Detectar modelo desde el 4° campo si no viene por parámetro
-    reported_device_name = (parts[3].strip() if len(parts) > 3 else "").strip()
-    model = (device or detect_model_from_identifiers(parts[2] if len(parts) > 2 else None, reported_device_name))
+    # Detectar modelo desde el campo IMEI, considerando si la trama trae el mensaje separado
+    imei_token = parts[2] if len(parts) > 2 else None
+    if first in {"+RESP:GT", "+BUFF:GT"} and len(parts) > 3:
+        imei_token = parts[3]
+
+    reported_device_name = (parts[4] if first in {"+RESP:GT", "+BUFF:GT"} else parts[3] if len(parts) > 3 else "")
+    reported_device_name = (reported_device_name or "").strip()
+
+    model = device or detect_model_from_identifiers(imei_token, reported_device_name)
     if not model:
         model = reported_device_name
     if not model:
@@ -51,11 +62,15 @@ def parse_gtinf(line: str, source: str = "RESP", device: Optional[str] = None) -
         else:
             raise
 
+    # Normalizar la línea según la spec (p. ej. separar header/message si el header es "+RESP:GTINF")
+    normalized_line = normalize_line_for_spec(line, "GTINF", spec)
+    parts = _tokenize(normalized_line, delimiter=spec.delimiter, terminator=spec.terminator)
+
     columns = [field.name for field in spec.fields]
 
     # Ahora mapeamos por posición respetando el orden exacto de la spec
     values: List[Optional[str]] = []
-    values.append(first)
+    values.append(parts[0] if parts else first)
 
     iterator = iter(parts[1:])
     for field in spec.fields[1:]:

--- a/queclink/parser.py
+++ b/queclink/parser.py
@@ -388,6 +388,9 @@ def normalize_line_for_spec(raw_line: str, message: str, spec: Optional[Spec]) -
         return raw_line
 
     normalized_message = _normalize_message_name(message or "")
+    has_message_field = any(getattr(field, "name", None) == "message" for field in spec.fields)
+    if has_message_field and raw_line.startswith(("+RESP:GT,", "+BUFF:GT,")):
+        return raw_line
     header_field = next((field for field in spec.fields if field.name == "header"), None)
     if not header_field or not header_field.const_any:
         return raw_line
@@ -470,6 +473,16 @@ def parse_line(
         )
         if value is not _SKIP:
             result[field.name] = value
+
+    if message == "GTERI" and "one_wire_device_number" not in result:
+        result["one_wire_device_number"] = 0
+
+    if message == "GTERI":
+        tail_tokens = _tokenize(line, delimiter=spec.delimiter, terminator=spec.terminator)
+        if len(tail_tokens) >= 1:
+            result["count_hex"] = tail_tokens[-1]
+        if len(tail_tokens) >= 2:
+            result["send_time"] = tail_tokens[-2]
 
     normalized_report = message
     if normalized_report:

--- a/queclink_tramas.py
+++ b/queclink_tramas.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import logging
 import sys
+from dataclasses import replace
 from pathlib import Path
 from typing import Iterable, Optional
 
@@ -17,6 +18,7 @@ from queclink.parser import (
     load_spec,
     normalize_line_for_spec,
     parse_line,
+    parse_gteri,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -88,6 +90,10 @@ def _process_line(
         )
         return False
 
+    records_spec = (
+        replace(spec, table_name=f"{head.report.lower()}_records") if expected_report else None
+    )
+
     normalized_line = normalize_line_for_spec(raw_line, head.report, spec)
 
     try:
@@ -108,11 +114,23 @@ def _process_line(
             _LOGGER.debug(
                 "Línea %s: se aplicó parsing relajado para GTINF (%s)", line_number, exc
             )
+        elif head.report.upper() == "GTERI":
+            record = parse_gteri(normalized_line, device=model)
+            if not record:
+                _LOGGER.warning(
+                    "Línea %s: error al parsear la trama (%s)", line_number, exc
+                )
+                return False
         else:
             _LOGGER.warning("Línea %s: error al parsear la trama (%s)", line_number, exc)
             return False
 
+    if head.report.upper() == "GTINF":
+        record["message"] = "INF"
+
     ingestor.insert(model, head.report, record, spec=spec)
+    if records_spec is not None:
+        ingestor.insert(model, head.report, record, spec=records_spec)
     return True
 
 

--- a/spec/gv310lau/gteri.yml
+++ b/spec/gv310lau/gteri.yml
@@ -44,8 +44,8 @@ schema:
         - { name: speed_kmh, type: float, min: 0.0, max: 999.9 }
         - { name: azimuth_deg, type: int, min: 0, max: 359 }
         - { name: altitude_m, type: float, note: "(-)xxxxx.x" }
-        - { name: longitude_deg, type: float, note: "(-)xxx.xxxxxx" }
-        - { name: latitude_deg, type: float, note: "(-)xx.xxxxxx" }
+        - { name: lon, type: float, note: "(-)xxx.xxxxxx" }
+        - { name: lat, type: float, note: "(-)xx.xxxxxx" }
         - { name: gnss_utc_time, type: datetime, format: "YYYYMMDDHHMMSS" }
 
         # GSM
@@ -128,40 +128,18 @@ schema:
 
         # Bits 3/4: Fuel Sensor Data (se muestra si cualquiera de los dos está activo)
         - name: fuel_sensor_block
-          type: object
-          when:
-            anyOf:
-              - { mask: eri_mask, bit: 3 }
-              - { mask: eri_mask, bit: 4 }
-          properties:
-            sensor_number: { type: int, min: 0, max: 100 }
-            sensors:
-              type: array
-              items:
-                type: object
-                properties:
-                  type: { type: int, enum: [0,1,2,3,4,6,8,20,21,22] }
-                  percentage:
-                    type: float
-                    min: 0.0
-                    max: 100.0
-                    nullable: true
-                    when: { mask: eri_mask, bit: 3 }
-                  volume_l:
-                    type: float
-                    min: 0.0
-                    max: 6000.0
-                    nullable: true
-                    when: { mask: eri_mask, bit: 4 }
-                  fuel_temperature_c:
-                    type: int
-                    min: -40
-                    max: 85
-                    nullable: true
-                    when:
-                      allOf:
-                        - { mask: eri_mask, bit: 10 }
-                        - { anyOf: [ { field: type, equals: 2 }, { field: type, equals: 6 } ] }
+          type: group
+          optional: true
+          enabled_if_any:
+            - { mask_field: eri_mask, bit: 3 }
+            - { mask_field: eri_mask, bit: 4 }
+          fields:
+            - name: fuel_temperature_c
+              type: int
+              optional: true
+              present_if_any:
+                - { field: fuel_type, equals: 2 }
+                - { field: fuel_type, equals: 6 }
 
         # Bit 7: RF433 Accessory Data
         - name: rf433_block
@@ -332,6 +310,19 @@ schema:
 
     - name: tail
       fields:
+        - name: rat
+          type: int
+          min: 0
+          max: 255
+          optional: true
+
+        - name: band
+          type: string
+          max_length: 8
+          optional: true
+          enabled_if_any:
+            - { field_present: rat }
+
         - { name: send_time, type: datetime, format: "YYYYMMDDHHMMSS" }
         - { name: count_hex, type: hex, length: 4 }
 
@@ -408,8 +399,8 @@ examples:
       - header
       - imei
       - eri_mask
-      - longitude_deg
-      - latitude_deg
+      - lon
+      - lat
       - position_append_mask
       - sats_in_use
       - hdop

--- a/spec/gv350ceu/gteri.yml
+++ b/spec/gv350ceu/gteri.yml
@@ -5,6 +5,50 @@ encoding: "ASCII"
 delimiter: ","
 terminator: "$"
 
+config:
+  table_fields:
+    - header
+    - message
+    - full_protocol_version
+    - imei
+    - device_name
+    - eri_mask
+    - external_power_mv
+    - report_type
+    - number
+    - gnss_accuracy
+    - speed_kmh
+    - azimuth_deg
+    - altitude_m
+    - lon
+    - lat
+    - gnss_utc_time
+    - mcc
+    - mnc
+    - lac_hex
+    - cell_id_hex
+    - position_append_mask
+    - satellites_in_use
+    - hdop
+    - vdop
+    - pdop
+    - gnss_trigger_type
+    - gnss_jamming_state
+    - mileage_km
+    - hour_meter
+    - analog_in_1
+    - analog_in_2
+    - analog_in_3
+    - backup_batt_percent
+    - device_status
+    - uart_device_type
+    - ble_count
+    - ble_accessories
+    - rat
+    - band
+    - send_time
+    - count_hex
+
 version_field:
   name: full_protocol_version
   length_variant: [6, 7]
@@ -17,10 +61,11 @@ schema:
     # =========================
     - name: head
       fields:
-        - { name: header, const_any: ["+RESP:GTERI", "+BUFF:GTERI"], type: string }
+        - { name: header, const_any: ["+RESP:GTERI", "+BUFF:GTERI", "+RESP:GT", "+BUFF:GT"], type: string }
+        - { name: message, const: "ERI", type: string }
         - { name: full_protocol_version, type: hex, length_variant: [6, 7] }
         - { name: imei, type: string, length: 15, pattern: "^[0-9]{15}$" }
-        - { name: device_name, type: string, max_length: 20 }
+        - { name: device_name, const: "GV350CEU", type: string }
 
     # ===================================
     # CUERPO FIJO (Siempre viene en GTERI)
@@ -36,8 +81,8 @@ schema:
         - { name: speed_kmh, type: float, min: 0.0, max: 999.9 }
         - { name: azimuth_deg, type: int, min: 0, max: 359 }
         - { name: altitude_m, type: float, min: -1000.0, max: 30000.0, optional: true }
-        - { name: lat, type: float, min: -90.0, max: 90.0 }
         - { name: lon, type: float, min: -180.0, max: 180.0 }
+        - { name: lat, type: float, min: -90.0, max: 90.0 }
         - { name: gnss_utc_time, type: datetime, format: "YYYYMMDDHHMMSS" }
 
         # ---- Red celular (fijo) ----
@@ -108,131 +153,22 @@ schema:
         - { name: device_status, type: hex, length_variant: [6, 10], optional: true, allow_empty: true }
         - { name: uart_device_type, type: int, min: 0, max: 7, optional: true, allow_empty: true }
 
-
-        # ===========================
-        # BLOQUES OPCIONALES AVANZADOS
-        # ===========================
-
-        # ---- Digital Fuel Sensor Data (ej. sensores digitales RS485/BLE) ----
-        - name: digital_fuel_count
-          type: int
-          min: 0
-          max: 8
-          optional: true
-
-        - name: digital_fuel_sensors
-          type: group_repeated
-          repeat: digital_fuel_count
-          optional: true
-          fields:
-            - { name: dfs_index, type: int, min: 0, max: 255 }
-            - { name: dfs_type, type: int, min: 0, max: 255, optional: true }
-            - { name: dfs_level_pct, type: float, min: 0, max: 100, optional: true }
-            - { name: dfs_temp_c, type: float, optional: true }
-            - { name: dfs_raw_hex, type: hex, max_length: 64, optional: true }
-
-        # ---- 1-Wire Data (iButton / Temp) ----
         - name: one_wire_device_number
           type: int
           min: 0
-          max: 19
+          max: 10
           optional: true
           default_if_absent: 0
-          present_if: { mask_field: eri_mask, bit: 1 }   # se muestra solo si el ERI Mask lo habilita
 
         - name: one_wire_devices
           type: group_repeated
           repeat: one_wire_device_number
           optional: true
-          enabled_if_any:
-            - { mask_field: eri_mask, bit: 1 }
           fields:
-            - { name: one_wire_device_id,   type: hex,   length_variant: [16] }
-            - { name: one_wire_device_type, type: int,   min: 1, max: 99, optional: true }   # 1 = temp sensor (DS18B20)
-            - { name: one_wire_device_data, type: hex,   max_length: 40, optional: true }    # crudo; para tipo 1 es complemento a dos
+            - { name: one_wire_device_id, type: hex, length_variant: [16], optional: true }
+            - { name: one_wire_device_type, type: int, min: 0, max: 255, optional: true }
+            - { name: one_wire_device_data, type: hex, max_length: 40, optional: true }
 
-
-        # ---- CAN Data (FMS/J1939/OBD-II vía adaptador externo) ----
-        - name: can_append_mask
-          type: hex
-          length_variant: [2, 4, 8]
-          optional: true
-
-        - name: can_engine_rpm
-          type: int
-          min: 0
-          max: 20000
-          optional: true
-          present_if: { mask_field: can_append_mask, bit: 0 }
-
-        - name: can_vehicle_speed_kmh
-          type: float
-          min: 0
-          max: 300
-          optional: true
-          present_if: { mask_field: can_append_mask, bit: 1 }
-
-        - name: can_fuel_level_pct
-          type: float
-          min: 0
-          max: 100
-          optional: true
-          present_if: { mask_field: can_append_mask, bit: 2 }
-
-        - name: can_total_fuel_used_l
-          type: float
-          min: 0
-          max: 1000000
-          optional: true
-          present_if: { mask_field: can_append_mask, bit: 3 }
-
-        - name: can_coolant_temp_c
-          type: float
-          optional: true
-          present_if: { mask_field: can_append_mask, bit: 4 }
-
-        - name: can_raw_hex
-          type: hex
-          max_length: 128
-          optional: true
-          present_if_any:
-            - { field_present: can_append_mask }
-
-        # ---- Fuel Sensor Data (analógico/voltaje) ----
-        - name: fuel_sensor_count
-          type: int
-          min: 0
-          max: 4
-          optional: true
-
-        - name: fuel_sensors
-          type: group_repeated
-          repeat: fuel_sensor_count
-          optional: true
-          fields:
-            - { name: fs_index, type: int, min: 0, max: 255 }
-            - { name: fs_voltage_mv, type: int, min: 0, max: 32000, optional: true }
-            - { name: fs_level_pct, type: float, min: 0, max: 100, optional: true }
-            - { name: fs_temp_c, type: float, optional: true }
-            - { name: fs_raw_hex, type: hex, max_length: 64, optional: true }
-
-        # ---- RF433 Accessory Data (ej. tags/mandos 433MHz) ----
-        - name: rf433_count
-          type: int
-          min: 0
-          max: 16
-          optional: true
-
-        - name: rf433_accessories
-          type: group_repeated
-          repeat: rf433_count
-          optional: true
-          fields:
-            - { name: rf433_type, type: int, min: 0, max: 255 }
-            - { name: rf433_id_hex, type: hex, length_variant: [4, 8, 12], optional: true }
-            - { name: rf433_event, type: int, min: 0, max: 255, optional: true }
-            - { name: rf433_rssi_dbm, type: int, min: -120, max: 0, optional: true }
-            - { name: rf433_raw_hex, type: hex, max_length: 64, optional: true }
 
         # ---- BLE (habilita bit 8 en eri_mask; mantenido) ----
         - name: ble_count

--- a/spec/gv37cau/gtinf.yml
+++ b/spec/gv37cau/gtinf.yml
@@ -68,7 +68,11 @@ schema:
           nullable: true
           description: "Voltaje fuente externa (mV). Campo puede venir vacío si no aplica."
 
-        - { name: network_type, type: int, enum: [0,1,2,3] }            # 0=unreg,1=EGPRS,2=WCDMA,3=LTE
+        - name: network_type
+          type: int
+          enum: [0, 1, 2, 3]
+          nullable: true
+          description: "Tipo de red (0=unreg,1=EGPRS,2=WCDMA,3=LTE). Puede venir vacío."
 
         - name: backup_batt_voltage_v
           type: float
@@ -87,9 +91,18 @@ schema:
           enum: [0, 1]
           description: "Estado LED (0 = apagado según config, 1 = encendido)"
 
-        - { name: reserved1, type: number, nullable: true }
-        
-        - { name: reserved2, type: number, nullable: true }
+        - name: power_saving_mode
+          type: int
+          min: 0
+          max: 2
+          nullable: true
+          description: "Modo de ahorro de energía (0=off,1=light,2=deep); puede venir vacío."
+
+        - name: external_gnss_antenna
+          type: int
+          enum: [0, 1]
+          nullable: true
+          description: "Estado de antena GNSS externa (0 = no detectada, 1 = conectada)."
 
         
         # --- Última fix y entradas/salidas ---
@@ -101,9 +114,19 @@ schema:
 
         - { name: pin_mask, type: hex, length_variant: [1,2] }
 
-        - { name: reserved3, type: number, nullable: true }
+        - name: analog_input1_mv
+          type: int
+          min: 0
+          max: 99999
+          nullable: true
+          description: "Lectura de entrada analógica 1 (mV)."
 
-        - { name: reserved4, type: number, nullable: true }
+        - name: analog_input2_mv
+          type: int
+          min: 0
+          max: 99999
+          nullable: true
+          description: "Lectura de entrada analógica 2 (mV)."
 
         - name: digital_input_status
           type: hex
@@ -138,7 +161,7 @@ schema:
           tz: "UTC"
           description: "Hora UTC en que se generó el reporte"
 
-        - name: count_number
+        - name: count_hex
           type: hex
           length: 4
           description: "Secuencia 0000–FFFF"

--- a/spec/gv58lau/gteri.yml
+++ b/spec/gv58lau/gteri.yml
@@ -220,6 +220,8 @@ schema:
           max_length: 8
           optional: true
           present_if: { field_present: rat }
+          enabled_if_any:
+            - { field_present: rat }
 
     - name: tail
       fields:

--- a/spec/gv75lau/gtinf.yml
+++ b/spec/gv75lau/gtinf.yml
@@ -36,16 +36,12 @@ schema:
         - { name: charging, type: int, enum: [0,1] }
         - { name: led_state, type: int, min: 0, max: 9, optional: true }
         - { name: power_saving_mode, type: int, min: 0, max: 2, optional: true }
-        - { name: reserved1, type: string, optional: true }
 
         # Tiempo de último fix GNSS
         - { name: last_fix_utc, type: datetime, format: "YYYYMMDDHHMMSS" }
 
         # Máscaras de IO
         - { name: pin_mask, type: hex, length_variant: [1,2], optional: true }
-        - { name: reserved2, type: string, optional: true }
-        - { name: reserved3, type: string, optional: true }
-        - { name: reserved4, type: string, optional: true }
         - { name: di_mask, type: hex, max_length: 2, optional: true }
         - { name: do_mask, type: hex, max_length: 2, optional: true }
 

--- a/tests/gv37cau/test_gtinf_message_parser.py
+++ b/tests/gv37cau/test_gtinf_message_parser.py
@@ -13,7 +13,7 @@ def test_parse_gtinf_resp_gv37cau():
     assert homologated["imei"] == "868487004398475"
     assert homologated["device_name"] == "GV37CAU"
     assert homologated["send_time"] == "20250314090005"
-    assert homologated["count_number"] == "0001"
+    assert homologated["count_hex"] == "0001"
 
 
 def test_parse_gtinf_buff_gv37cau_without_device_name():
@@ -28,4 +28,4 @@ def test_parse_gtinf_buff_gv37cau_without_device_name():
     assert homologated["imei"] == "868487004398475"
     assert homologated["device_name"] is None
     assert homologated["send_time"] == "20250314090751"
-    assert homologated["count_number"] == "0999"
+    assert homologated["count_hex"] == "0999"


### PR DESCRIPTION
## Summary
- Ajusta los esquemas GTINF/GTERI para GV37, GV75, GV58, GV350 y GV310, corrigiendo campos opcionales, máscaras y nombres de columnas.
- Refuerza el parser GTINF/GTERI y la CLI para normalizar encabezados, soportar tablas genéricas y tolerar faltantes como conteos 1-Wire.
- Permite definir columnas de tabla mediante `table_fields` en las specs de GTERI y actualiza pruebas acordes.

## Testing
- pytest -q --disable-warnings


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b78fb3a988333872fcedb18a00203)