### PR TITLE
Adjust GV37CAU GTINF spec structure

### DIFF
--- a/spec/gv37cau/gtinf.yml
+++ b/spec/gv37cau/gtinf.yml
@@ -114,8 +114,6 @@ schema:
 
         - { name: reserved3, type: string, optional: true }
 
-        - { name: reserved4, type: string, optional: true }
-
         - name: digital_input_status
           type: hex
           length_max: 4


### PR DESCRIPTION
## Summary
- align the GV37CAU GTINF schema with the expected field order by removing an extra reserved field
- keep all other device homologations untouched

## Testing
- pytest tests/gv37cau/test_gtinf_message_parser.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b86478774833386d73c3fa9299bef)