### PR TITLE
Add GV37CAU enriched map database tests

### DIFF
--- a/tests/viz/test_mapa_recorridos.py
+++ b/tests/viz/test_mapa_recorridos.py
@@ -195,3 +195,137 @@ def test_ensure_map_databases_enriches_gtfri_gv75lau(tmp_path: Path) -> None:
         ("20251029091530", "4G", "Excelente", 20.0, "WOM"),
         ("20251029092000", "3G", "Regular", -93.0, "Claro"),
     ]
+
+
+def _setup_gv37_sources(tmp_path: Path) -> tuple[Path, str, str]:
+    base_dir = tmp_path
+    model = "gv37cau"
+    imei = "868487004398475"
+
+    gteri_source = base_dir / f"gteri_{model}.db"
+    conn = sqlite3.connect(gteri_source)
+    table_name = f"gteri_{model}"
+    conn.execute(
+        f"""
+        CREATE TABLE "{table_name}" (
+            imei TEXT,
+            gnss_utc_time TEXT,
+            latitude_deg REAL,
+            longitude_deg REAL,
+            header TEXT
+        )
+        """
+    )
+    conn.executemany(
+        f'INSERT INTO "{table_name}" (imei, gnss_utc_time, latitude_deg, longitude_deg, header) '
+        "VALUES (?, ?, ?, ?, ?)",
+        [
+            (imei, "20251101090000", -33.45, -70.66, "+RESP:GTERI"),
+            (imei, "20251101091500", -33.46, -70.65, "+BUFF:GTERI"),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    gtfri_source = base_dir / f"gtfri_{model}.db"
+    conn = sqlite3.connect(gtfri_source)
+    table_name = f"gtfri_{model}"
+    conn.execute(
+        f"""
+        CREATE TABLE "{table_name}" (
+            imei TEXT,
+            gnss_utc_time TEXT,
+            latitude_deg REAL,
+            longitude_deg REAL,
+            header TEXT
+        )
+        """
+    )
+    conn.executemany(
+        f'INSERT INTO "{table_name}" (imei, gnss_utc_time, latitude_deg, longitude_deg, header) '
+        "VALUES (?, ?, ?, ?, ?)",
+        [
+            (imei, "20251101120000", -33.47, -70.64, "+RESP:GTFRI"),
+            (imei, "20251101121500", -33.48, -70.63, "+BUFF:GTFRI"),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    gtinf_source = base_dir / f"gtinf_{model}.db"
+    conn = sqlite3.connect(gtinf_source)
+    table_name = f"gtinf_{model}"
+    conn.execute(
+        f"""
+        CREATE TABLE "{table_name}" (
+            imei TEXT,
+            send_time TEXT,
+            network_type INTEGER,
+            csq REAL,
+            csq_ber INTEGER,
+            operador TEXT,
+            mcc INTEGER,
+            mnc INTEGER
+        )
+        """
+    )
+    conn.executemany(
+        f'INSERT INTO "{table_name}" (imei, send_time, network_type, csq, csq_ber, operador, mcc, mnc) '
+        'VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+        [
+            (imei, "20251101090000", 3, 160.0, None, "WOM", None, None),
+            (imei, "20251101091500", 2, 12.0, 5, "", 730, 3),
+            (imei, "20251101120000", 3, 155.0, None, "Entel", None, None),
+            (imei, "20251101121500", 1, 24.0, None, "", 730, 2),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    return base_dir, model, imei
+
+
+def test_ensure_map_databases_enriches_gv37cau_gteri(tmp_path: Path) -> None:
+    base_dir, model, _ = _setup_gv37_sources(tmp_path)
+
+    results = ensure_map_databases(model=model, base_dir=base_dir, reports=["gteri"])
+
+    assert set(results) == {"gteri"}
+    db_path = results["gteri"]
+    assert db_path.exists()
+
+    conn = sqlite3.connect(db_path)
+    rows = conn.execute(
+        f'SELECT gnss_utc_time, tecnologia_celular, calidad_senal, nivel_senal_dbm, operador '
+        f'FROM "gteri_{model}" ORDER BY gnss_utc_time'
+    ).fetchall()
+    conn.close()
+
+    summary = [tuple(row) for row in rows]
+    assert summary == [
+        ("20251101090000", "4G", "Excelente", 20.0, "WOM"),
+        ("20251101091500", "3G", "Buena", -89.0, "Claro"),
+    ]
+
+
+def test_ensure_map_databases_enriches_gv37cau_gtfri(tmp_path: Path) -> None:
+    base_dir, model, _ = _setup_gv37_sources(tmp_path)
+
+    results = ensure_map_databases(model=model, base_dir=base_dir, reports=["gtfri"])
+
+    assert set(results) == {"gtfri"}
+    db_path = results["gtfri"]
+    assert db_path.exists()
+
+    conn = sqlite3.connect(db_path)
+    rows = conn.execute(
+        f'SELECT gnss_utc_time, tecnologia_celular, calidad_senal, nivel_senal_dbm, operador '
+        f'FROM "gtfri_{model}" ORDER BY gnss_utc_time'
+    ).fetchall()
+    conn.close()
+
+    summary = [tuple(row) for row in rows]
+    assert summary == [
+        ("20251101120000", "4G", "Excelente", 15.0, "Entel"),
+        ("20251101121500", "2G", "Excelente", -65.0, "Movistar"),
+    ]


### PR DESCRIPTION
## Summary
- add GV37CAU fixtures for GTERI, GTFRI and GTINF sources used in map enrichment
- verify enriched database generation populates signal and operator details for GV37CAU

## Testing
- pytest tests/viz/test_mapa_recorridos.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c5dca2f908333b00498f12d9e1534)