### PR TITLE
Add GV30CAU homologation specs and parsing support

### DIFF
--- a/queclink/parser.py
+++ b/queclink/parser.py
@@ -20,6 +20,7 @@ _MODEL_PREFIXES = {
     "86631406": "gv58lau",
     "86858906": "gv310lau",
     "86252406": "gv350ceu",
+    "868487004": "gv30cau",
     "86848700": "gv37cau",
 }
 
@@ -28,6 +29,7 @@ _DEVICE_NAME_MODELS = {
     "GV310LAU": "gv310lau",
     "GV350CEU": "gv350ceu",
     "GV75LAU": "gv75lau",
+    "GV30CAU": "gv30cau",
     "GV37CAU": "gv37cau",
 }
 
@@ -249,8 +251,14 @@ def model_from_imei(imei: str) -> Optional[str]:
     digits = "".join(ch for ch in str(imei) if ch.isdigit())
     if len(digits) < 8:
         return None
-    prefix = digits[:8]
-    return _MODEL_PREFIXES.get(prefix)
+
+    prefix_lengths = sorted({len(key) for key in _MODEL_PREFIXES}, reverse=True)
+    for length in prefix_lengths:
+        prefix = digits[:length]
+        model = _MODEL_PREFIXES.get(prefix)
+        if model:
+            return model
+    return None
 
 
 def _model_from_device_name(name: Optional[str]) -> Optional[str]:

--- a/spec/gv30cau/gteri.yml
+++ b/spec/gv30cau/gteri.yml
@@ -5,196 +5,123 @@ encoding: "ASCII"
 delimiter: ","
 terminator: "$"
 
-# --- Compatibilidad / features ---
-
 config:
-
-# ERI Mask decide si se reporta GTERI en lugar de GTFRI cuando hay periféricos
-
-# y controla bloques/campos opcionales (p.ej. RAT/Band Data).
-
-# Para GV30CAU el documento menciona explícitamente:
-
-# - bit15 => incluye <RAT and Band Data> en +RESP:GTERI (Optional)
-
-eri_mask_bits: "bit15=rat_band_data; otros bits reservados/periféricos según configuración"
+  eri_mask_bits: "bit15=rat_band_data; otros bits reservados/periféricos según configuración"
 
 version_field:
-name: full_protocol_version
-length: 10
-format: hex
-example: "8020210100"
+  name: full_protocol_version
+  length: 10
+  format: hex
+  example: "8020210100"
 
 schema:
-sections:
-- name: head
-fields:
-- { name: header, const_any: ["+RESP:GTERI", "+BUFF:GTERI"], type: string }
-- { name: full_protocol_version, type: hex, length: 10, example: "8020210100" }
-- { name: imei, type: string, length: 15, pattern: "^[0-9]{15}$", example: "868487004398475" }
-- { name: device_name, type: string, max_length: 20, pattern: "^[0-9A-Za-z_-]{1,20}$", example: "GV30CAU" }
+  sections:
+    - name: head
+      fields:
+        - { name: header, const_any: ["+RESP:GTERI", "+BUFF:GTERI"], type: string }
+        - { name: full_protocol_version, type: hex, length: 10, example: "8020210100" }
+        - { name: imei, type: string, length: 15, pattern: "^[0-9]{15}$", example: "868487004398475" }
+        - { name: device_name, type: string, max_length: 20, pattern: "^[0-9A-Za-z_-]{1,20}$", example: "GV30CAU" }
 
-```
-- name: body
-  fields:
-    # --- Cabecera ERI ---
-    - name: eri_mask
-      type: hex
-      length: 8
-      example: "00008000"
-      description: >
-        ERI Mask (32 bits, representado como 8 HEX ASCII).
-        Si el equipo tiene periféricos y el bit correspondiente está en 1, reporta GTERI en vez de GTFRI.
+    - name: body
+      fields:
+        # --- Cabecera ERI ---
+        - name: eri_mask
+          type: hex
+          length: 8
+          example: "00008000"
+        - name: external_power_mv
+          type: int
+          min: 0
+          max: 99999
+          nullable: true
+        - { name: report_id_report_type, type: string, length: 2 }
+        - { name: number, type: int, min: 1, max: 15 }
 
-    - name: external_power_mv
-      type: int
-      min: 0
-      max: 99999
-      nullable: true
-      description: "External Power Voltage (mV). Puede venir vacío (coma-coma) según config."
+        # --- Posición GNSS ---
+        - { name: gnss_accuracy_level, type: int, min: 0, max: 50 }
+        - { name: speed_kmh, type: float, min: 0.0, max: 999.9 }
+        - { name: azimuth_deg, type: int, min: 0, max: 359 }
+        - { name: altitude_m, type: float, nullable: true }
+        - { name: longitude_deg, type: float, nullable: true }
+        - { name: latitude_deg, type: float, nullable: true }
+        - { name: gnss_utc_time, type: datetime, format: "YYYYMMDDHHMMSS", tz: "UTC" }
 
-    - name: report_id_report_type
-      type: string
-      length: 2
-      description: "Report ID / Report Type (2 caracteres)."
+        # --- GSM/Red ---
+        - { name: mcc, type: string, pattern: "^0[0-9]{3}$" }
+        - { name: mnc, type: string, pattern: "^0[0-9]{3}$" }
+        - { name: lac, type: hex, length: 4 }
+        - { name: cell_id, type: hex, length_variant: [4, 8] }
 
-    - name: number
-      type: int
-      min: 1
-      max: 15
-      description: "Número de puntos (normalmente 1)."
+        # --- Position Append Mask ---
+        - { name: position_append_mask, type: hex, length: 2, example: "01" }
+        - name: sats_in_use
+          type: int
+          min: 0
+          max: 72
+          nullable: true
+          when: { mask: position_append_mask, bit: 0 }
+        - name: gnss_trigger_type
+          type: int
+          min: 0
+          max: 4
+          nullable: true
+          optional: true
+          when: { mask: position_append_mask, bit: 1 }
 
-    # --- Posición GNSS ---
-    - { name: gnss_accuracy_level, type: int, min: 0, max: 50 }
-    - { name: speed_kmh, type: float, min: 0.0, max: 999.9 }
-    - { name: azimuth_deg, type: int, min: 0, max: 359 }
-    - { name: altitude_m, type: float, nullable: true, note: "(-)xxxxx.x (m)" }
-    - { name: longitude_deg, type: float, nullable: true, note: "(-)xxx.xxxxxx" }
-    - { name: latitude_deg, type: float, nullable: true, note: "(-)xx.xxxxxx" }
+        # --- Contadores / hour meter / CSQ ---
+        - { name: total_mileage_km, type: float, min: 0.0, max: 4294967.0 }
+        - name: current_hour_meter_hhmmss
+          type: string
+          nullable: true
+          pattern: "^[0-9]{6}$"
+        - name: total_hour_meter
+          type: string
+          nullable: true
+          pattern: "^[0-9]{5,7}:[0-5][0-9]:[0-5][0-9]$"
+        - name: analog_input1_mv
+          type: int
+          min: 0
+          max: 16000
+          nullable: true
+        - { name: reserved1, type: number, nullable: true }
+        - { name: backup_batt_pct, type: int, min: 0, max: 100, nullable: true, optional: true }
 
-    - name: gnss_utc_time
-      type: datetime
-      format: "YYYYMMDDHHMMSS"
-      tz: "UTC"
-      description: "GNSS UTC Time."
+        # --- Estado equipo ---
+        - { name: device_status, type: hex, length: 6, example: "210100" }
+        - { name: reserved2, type: string, nullable: true, optional: true }
 
-    # --- GSM/Red ---
-    - { name: mcc, type: string, pattern: "^0[0-9]{3}$", description: "0XXX" }
-    - { name: mnc, type: string, pattern: "^0[0-9]{3}$", description: "0XXX" }
-    - { name: lac, type: hex, length: 4 }
-    - { name: cell_id, type: hex, length_variant: [4, 8] }
+        # --- RAT / Band data (Optional, ERI Mask bit15) ---
+        - name: rat
+          type: int
+          min: 0
+          max: 4
+          nullable: true
+          optional: true
+          when: { mask: eri_mask, bit: 15 }
+        - name: band
+          type: int
+          min: 0
+          max: 1900
+          nullable: true
+          optional: true
+          when: { mask: eri_mask, bit: 15 }
+        - { name: reserved3, type: string, nullable: true, optional: true }
+        - { name: reserved4, type: string, nullable: true, optional: true }
 
-    # --- Position Append Mask (igual semántica que GTFRI) ---
-    - name: position_append_mask
-      type: hex
-      length: 2
-      example: "01"
-      description: >
-       Position Append Mask (1 byte).
-       Define la presencia de campos opcionales posteriores:
-       bit0 = Satellites in Use
-       bit1 = GNSS Trigger Type
-
-    - name: sats_in_use
-      type: int
-      min: 0
-      max: 72
-      nullable: true
-      when: { mask: position_append_mask, bit: 0 }
-      description: "Número de satélites GNSS en uso (si bit0 = 1)."
-
-    - name: gnss_trigger_type
-      type: int
-      min: 0
-      max: 4
-      nullable: true
-      optional: true
-      when: { mask: position_append_mask, bit: 1 }
-      description: >
-       GNSS Trigger Type (Optional).
-       0=Time, 1=Corner, 2=Distance, 3=Mileage, 4=Optimum.
-       Solo presente si bit1 del Position Append Mask = 1.
-
-    # --- Contadores / hour meter / CSQ ---
-    - name: total_mileage_km
-      type: float
-      min: 0.0
-      max: 4294967.0
-      description: "Total Mileage (km)."
-
-    - name: current_hour_meter_hhmmss
-      type: string
-      nullable: true
-      pattern: "^[0-9]{6}$"
-      example: "102334"
-      description: "Current Hour Meter Count (HHMMSS). Si no aplica, vacío."
-
-    - name: total_hour_meter
-      type: string
-      nullable: true
-      pattern: "^[0-9]{5,7}:[0-5][0-9]:[0-5][0-9]$"
-      example: "0000102:34:33"
-      description: >
-        Total Hour Meter Count (HHHHH-HHHHHHH:MM:SS). Si la función está deshabilitada, vacío.
-
-    - name: analog_input1_mv type: int min: 0 max: 16000 nullable: true description: "Analog Input 1 (mV)." 
-    - { name: reserved1, type: number, nullable: true, description: "Reserved (documentado como 0 / vacío)." } 
-    - { name: reserved2, type: number, nullable: true, description: "Reserved (documentado como 0 / vacío)." }
-
-    - name: backup_batt_pct type: int min: 0 max: 100 nullable: true description: "Backup Battery Percentage (0-100)."
-
-    # --- Estado equipo ---
-    - name: device_status
-      type: hex
-      length: 6
-      example: "210100"
-      description: "Device Status (Motion/Input/Output en 6 HEX)."
-
-    - { name: reserved3, type: string, nullable: true, description: "Reserved (puede venir vacío)." }
-
-    # --- RAT / Band data (Optional, controlado por ERI Mask bit15) ---
-    - name: rat
-      type: int
-      min: 0
-      max: 4
-      nullable: true
-      optional: true
-      when: { mask: eri_mask, bit: 15 }
-      description: "RAT (0=No Service, 1=EGPRS, 4=LTE Cat1). Se incluye si ERI Mask bit15=1."
-
-    - name: band
-      type: int
-      min: 0
-      max: 1900
-      nullable: true
-      optional: true
-      when: { mask: eri_mask, bit: 15 }
-      description: "Band (LTE band o GSM band según RAT). Se incluye si ERI Mask bit15=1."
-
-- name: tail
-  fields:
-    - { name: send_time, type: datetime, format: "YYYYMMDDHHMMSS", tz: "UTC" }
-    - { name: count_number, type: hex, length: 4 }
-    - { name: tail, const: "$", type: string, optional: true, default_if_absent: "$" }
-```
+    - name: tail
+      fields:
+        - { name: send_time, type: datetime, format: "YYYYMMDDHHMMSS", tz: "UTC" }
+        - { name: count_number, type: hex, length: 4 }
+        - { name: tail, const: "$", type: string, optional: true, default_if_absent: "$" }
 
 masks:
-eri_mask:
-size_bits: 32
-bits:
-15: { field: rat, description: "Incluye <RAT and Band Data> (Optional) en +RESP/+BUFF:GTERI." }
-
-notes:
-
-* "Cuando el equipo está conectado a periféricos y el bit correspondiente en ERI Mask está en 1, el equipo reporta +RESP:GTERI en vez de +RESP:GTFRI."
-* "En GV30CAU se documenta explícitamente el uso de ERI Mask bit15 para habilitar el bloque opcional <RAT and Band Data>."
-* "El campo posterior a Cell ID es 'Reserved | GNSS Trigger Type(Optional)' y puede venir '00' o vacío; si viene 0-4 representa tipo de disparo."
-* "Total Hour Meter Count: si se habilita el hour meter, el total se reporta como H(5..7):MM:SS; si se deshabilita, el campo viene vacío."
-* "Los timestamps GNSS UTC Time y Send Time están en UTC y deben convertirse a horario oficial de Chile continental en tu aplicación (considerando DST)."
+  eri_mask:
+    size_bits: 32
+    bits:
+      15: { field: rat, description: "Incluye <RAT and Band Data> en +RESP/+BUFF:GTERI." }
 
 examples:
-raw_frames:
-# Ejemplo oficial (ASCII) del documento GV30CAU:
-- "+RESP:GTERI,8020210100,868487004398475,GV30CAU,00008000,,10,1,1,0.0,183,151.1,117.129417,31.839262,20250307030112,0460,0001,DF5C,027A4F1F,00,13.6,,,,,,210100,,4,3,20250307030112,0ACC$"
-# Ejemplo sintético +BUFF con RAT/Band omitidos (si bit15=0 o campos vacíos):
-- "+BUFF:GTERI,8020210100,868487004398475,GV30CAU,00000000,12000,10,1,5,60.0,180,50.0,117.129417,31.839262,20250307030323,0460,0001,DF5C,027A4F1F,00,12345.6,000000,0000012:34:56,28,0,210100,,,,20250307030325,00AF$"
+  raw_frames:
+    - "+RESP:GTERI,8020210100,868487004398475,GV30CAU,00008000,,10,1,1,0.0,183,151.1,117.129417,31.839262,20250307030112,0460,0001,DF5C,027A4F1F,00,13.6,,,,,,210100,,4,3,20250307030112,0ACC$"
+    - "+BUFF:GTERI,8020210100,868487004398475,GV30CAU,00000000,12000,10,1,5,60.0,180,50.0,117.129417,31.839262,20250307030323,0460,0001,DF5C,027A4F1F,00,12345.6,000000,0000012:34:56,28,0,210100,,,,20250307030325,00AF$"

--- a/spec/gv30cau/gtfri.yml
+++ b/spec/gv30cau/gtfri.yml
@@ -5,162 +5,108 @@ encoding: "ASCII"
 delimiter: ","
 terminator: "$"
 
-# --- Configuración/Features para compatibilidad ---
-
 config:
-
-# Según protocolo GV30CAU, el Position Append Mask controla campos opcionales después de <Cell ID>.
-
-# Documentado explícitamente:
-
-# - bit0 => Satellites in Use
-
-# - bit1 => GNSS Trigger Type (opcional)
-
-# Otros bits: reservados/no documentados para GTFRI en este documento.
-
-position_append_mask_bits: "bit0=sats_in_use; bit1=gnss_trigger_type; otros reservados"
+  position_append_mask_bits: "bit0=sats_in_use; bit1=gnss_trigger_type; otros reservados"
 
 version_field:
-name: full_protocol_version
-length: 10
-format: hex
-example: "8020210100"
+  name: full_protocol_version
+  length: 10
+  format: hex
+  example: "8020210100"
 
 schema:
-sections:
-- name: head
-fields:
-- { name: header, const_any: ["+RESP:GTFRI", "+BUFF:GTFRI"], type: string }
-- { name: full_protocol_version, type: hex, length: 10, example: "8020210100" }
-- { name: imei, type: string, length: 15, pattern: "^[0-9]{15}$", example: "868487004398921" }
-- { name: device_name, type: string, max_length: 20, pattern: "^[0-9A-Za-z_-]{1,20}$", example: "GV30CAU" }
+  sections:
+    - name: head
+      fields:
+        - { name: header, const_any: ["+RESP:GTFRI", "+BUFF:GTFRI"], type: string }
+        - { name: full_protocol_version, type: hex, length: 10, example: "8020210100" }
+        - { name: imei, type: string, length: 15, pattern: "^[0-9]{15}$", example: "868487004398921" }
+        - { name: device_name, type: string, max_length: 20, pattern: "^[0-9A-Za-z_-]{1,20}$", example: "GV30CAU" }
 
-```
-- name: body
-  fields:
-    - name: external_power_mv
-      type: int
-      min: 0
-      max: 99999
-      nullable: true
-      description: "External Power Voltage (mV). Puede venir vacío en algunos reportes/configuraciones."
-      # En ejemplo del protocolo, aparece vacío inmediatamente después del device_name.
-      # +RESP:GTFRI,...,GV30CAU,,10,...
+    - name: body
+      fields:
+        - name: external_power_mv
+          type: int
+          min: 0
+          max: 99999
+          nullable: true
+          description: "External Power Voltage (mV). Puede venir vacío en algunas configuraciones."
 
-    - name: report_id_report_type
-      type: string
-      length: 2
-      description: "Report ID / Report Type (X(1-5)Y(0-6))."
-      note: "Campo de 2 caracteres ASCII; el documento lo define como 'Report ID / Report Type'."
+        - name: report_id_report_type
+          type: string
+          length: 2
+          description: "Report ID / Report Type (X(1-5)Y(0-6))."
 
-    - name: number
-      type: int
-      min: 1
-      max: 15
-      description: "Número de posiciones incluidas (generalmente 1)."
+        - name: number
+          type: int
+          min: 1
+          max: 15
+          description: "Número de posiciones incluidas (generalmente 1)."
 
-    # --- Posición GNSS ---
-    - { name: gnss_accuracy_level, type: int, min: 0, max: 50, description: "GNSS Accuracy (HDOP / estado fix)." }
-    - { name: speed_kmh, type: float, min: 0.0, max: 999.9, description: "Speed (km/h)." }
-    - { name: azimuth_deg, type: int, min: 0, max: 359, description: "Azimuth (0-359)." }
-    - { name: altitude_m, type: float, nullable: true, note: "(-)xxxxx.x (m)", description: "Altitude (m)." }
-    - { name: longitude_deg, type: float, nullable: true, note: "(-)xxx.xxxxxx", description: "Longitude." }
-    - { name: latitude_deg, type: float, nullable: true, note: "(-)xx.xxxxxx", description: "Latitude." }
-    - { name: gnss_utc_time, type: datetime, format: "YYYYMMDDHHMMSS", tz: "UTC" }
+        # --- Posición GNSS ---
+        - { name: gnss_accuracy_level, type: int, min: 0, max: 50 }
+        - { name: speed_kmh, type: float, min: 0.0, max: 999.9 }
+        - { name: azimuth_deg, type: int, min: 0, max: 359 }
+        - { name: altitude_m, type: float, nullable: true }
+        - { name: longitude_deg, type: float, nullable: true }
+        - { name: latitude_deg, type: float, nullable: true }
+        - { name: gnss_utc_time, type: datetime, format: "YYYYMMDDHHMMSS", tz: "UTC" }
 
-    # --- GSM/Red ---
-    - { name: mcc, type: string, pattern: "^0[0-9]{3}$", description: "MCC (0XXX)." }
-    - { name: mnc, type: string, pattern: "^0[0-9]{3}$", description: "MNC (0XXX)." }
-    - { name: lac, type: hex, length: 4, description: "LAC (XXXX)." }
-    - { name: cell_id, type: hex, length_variant: [4, 8], description: "Cell ID (XXXX o XXXXXXXX)." }
+        # --- GSM/Red ---
+        - { name: mcc, type: string, pattern: "^0[0-9]{3}$" }
+        - { name: mnc, type: string, pattern: "^0[0-9]{3}$" }
+        - { name: lac, type: hex, length: 4 }
+        - { name: cell_id, type: hex, length_variant: [4, 8] }
 
-    # --- Position Append Mask y campos dependientes ---
-    - { name: position_append_mask, type: hex, length: 2, example: "00", description: "Position Append Mask (00-FF)." }
+        # --- Position Append Mask ---
+        - { name: position_append_mask, type: hex, length: 2, example: "00" }
+        - name: sats_in_use
+          type: int
+          min: 0
+          max: 72
+          when: { mask: position_append_mask, bit: 0 }
+        - name: gnss_trigger_type
+          type: int
+          min: 0
+          max: 4
+          optional: true
+          nullable: true
+          when: { mask: position_append_mask, bit: 1 }
 
-    - name: sats_in_use
-      type: int
-      min: 0
-      max: 72
-      when: { mask: position_append_mask, bit: 0 }
-      description: "Satellites in Use (si bit0=1)."
+        # --- Odómetro / Horómetro / AI ---
+        - { name: mileage_km, type: float, min: 0.0, max: 4294967.0 }
+        - name: hour_meter
+          type: string
+          nullable: true
+          pattern: "^[0-9]{5,7}:[0-5][0-9]:[0-5][0-9]$"
+        - name: analog_input1_mv
+          type: int
+          min: 0
+          max: 16000
+          nullable: true
+        - { name: reserved1, type: number, nullable: true }
+        - { name: reserved2, type: number, nullable: true }
+        - { name: backup_batt_pct, type: int, min: 0, max: 100, nullable: true }
+        - { name: device_status, type: hex, length: 6, example: "220100" }
+        - { name: reserved3, type: number, nullable: true }
+        - { name: reserved4, type: number, nullable: true }
+        - { name: reserved5, type: number, nullable: true }
+        - { name: reserved6, type: number, nullable: true, optional: true }
 
-    - name: gnss_trigger_type
-      type: int
-      min: 0
-      max: 4
-      optional: true
-      nullable: true
-      when: { mask: position_append_mask, bit: 1 }
-      description: >
-        GNSS Trigger Type (0-4) si bit1=1.
-        Nota: el documento marca este campo como 'Optional'.
-
-    # --- Odómetro / Horómetro / AI ---
-    - { name: mileage_km, type: float, min: 0.0, max: 4294967.0, description: "Mileage (km)." }
-
-    - name: hour_meter
-      type: string
-      nullable: true
-      pattern: "^[0-9]{5,7}:[0-5][0-9]:[0-5][0-9]$"
-      example: "0000102:34:33"
-      description: "Hour Meter Count (HHHHH-HHHHHHH:MM:SS). Si está deshabilitado, viene vacío."
-
-    - name: analog_input1_mv
-      type: int
-      min: 0
-      max: 16000
-      nullable: true
-      description: "Analog Input 1 (mV). Si no aplica, puede venir vacío."
-
-    # El documento lista dos 'Reserved 0' seguidos luego de Analog Input 1.
-    - { name: reserved1, type: number, nullable: true, description: "Reserved (documentado como 0 / vacío)." }
-    - { name: reserved2, type: number, nullable: true, description: "Reserved (documentado como 0 / vacío)." }
-
-    - name: backup_batt_pct
-      type: int
-      min: 0
-      max: 100
-      nullable: true
-      description: "Backup Battery Percentage (0-100)."
-
-    - name: device_status
-      type: hex
-      length: 6
-      example: "220100"
-      description: "Device Status (6 HEX). Primeros 2 bytes=motion; 2 bytes=input; 2 bytes=output."
-
-    # El documento indica un Reserved 0 antes de RAT/Band (Optional).
-    - { name: reserved3, type: number, nullable: true, description: "Reserved (documentado como 0 / vacío)." }
-    - { name: reserved4, type: number, nullable: true, description: "Reserved (documentado como 0 / vacío)." }
-    - { name: reserved5, type: number, nullable: true, description: "Reserved (documentado como 0 / vacío)." }
-
-
-- name: tail
-  fields:
-    - { name: send_time, type: datetime, format: "YYYYMMDDHHMMSS", tz: "UTC" }
-    - { name: count_number, type: hex, length: 4, description: "Count Number (0000-FFFF)." }
-    - { name: tail, const: "$", type: string, optional: true, default_if_absent: "$" }
-```
+    - name: tail
+      fields:
+        - { name: send_time, type: datetime, format: "YYYYMMDDHHMMSS", tz: "UTC" }
+        - { name: count_number, type: hex, length: 4 }
+        - { name: tail, const: "$", type: string, optional: true, default_if_absent: "$" }
 
 masks:
-position_append_mask:
-size_bits: 8
-bits:
-0: { field: sats_in_use, description: "Satellites in Use" }
-1: { field: gnss_trigger_type, description: "GNSS Trigger Type (Optional)" }
-
-notes:
-
-* "GTFRI (ASCII) se envía cuando el fixed report está habilitado. Si se habilita +RESP:GTERI, el equipo puede enviar GTERI en lugar de GTFRI."
-* "External Power Voltage puede venir vacío (se observa en el ejemplo oficial: ...GV30CAU,,10,...)."
-* "Position Append Mask controla campos opcionales después de Cell ID: bit0=satélites; bit1=GNSS Trigger Type."
-* "RAT y Band data son 'Optional' y dependen del ERI Mask del comando AT+GTFRI."
-* "GNSS UTC Time y Send Time están en UTC; convertir a hora oficial de Chile continental en la aplicación (considerando DST vigente)."
+  position_append_mask:
+    size_bits: 8
+    bits:
+      0: { field: sats_in_use, description: "Satellites in Use" }
+      1: { field: gnss_trigger_type, description: "GNSS Trigger Type (Optional)" }
 
 examples:
-raw_frames:
-# Ejemplo oficial del documento (con campos vacíos/optional):
-- "+RESP:GTFRI,8020210100,868487004398921,GV30CAU,,10,1,1,26.6,66,21.2,117.248633,31.855967,20250307020609,0460,0000,5666,05C5DF2D,00,13.3,,,,,,220100,,,,20250307020611,2800$"
-# Ejemplo sintético +BUFF (misma estructura):
-- "+BUFF:GTFRI,8020210100,868487004398921,GV30CAU,12000,10,1,5,60.0,180,50.0,117.129417,31.839262,20250307030323,0460,0001,DF5C,027A4F1F,03,12,2,12345.6,0000012:34:56,12000,0,0,80,220100,0,4,28,,20250307030325,00AF$"
+  raw_frames:
+    - "+RESP:GTFRI,8020210100,868487004398921,GV30CAU,,10,1,1,26.6,66,21.2,117.248633,31.855967,20250307020609,0460,0000,5666,05C5DF2D,00,13.3,,,,,,220100,,,,20250307020611,2800$"
+    - "+BUFF:GTFRI,8020210100,868487004398921,GV30CAU,12000,10,1,5,60.0,180,50.0,117.129417,31.839262,20250307030323,0460,0001,DF5C,027A4F1F,03,12,2,12345.6,0000012:34:56,12000,0,0,80,220100,0,4,28,,20250307030325,00AF$"

--- a/spec/gv30cau/gtinf.yml
+++ b/spec/gv30cau/gtinf.yml
@@ -9,7 +9,7 @@ version_field:
   name: full_protocol_version
   length: 10
   format: hex
- example: "8020210200" # Ejemplo visto en reportes GV30CAU del protocolo
+  example: "8020210200"
 
 schema:
   sections:
@@ -23,128 +23,47 @@ schema:
           max_length: 20
           pattern: "^[0-9A-Za-z_-]{0,20}$"
           nullable: true
-          description: "Device Name configurado; puede venir vacío."
 
     - name: body
       fields:
-        # --- Estado y SIM/GSM ---
         - name: motion_status
           type: hex
           length: 2
-          description: "Estado de movimiento actual (11,12,16,1A,21,22,41,42)."
-          enum:
-            "11": "Ignition Off Rest"
-            "12": "Ignition Off Motion"
-            "16": "Tow"
-            "1A": "Fake Tow"
-            "21": "Ignition On Rest"
-            "22": "Ignition On Motion"
-            "41": "Sensor Rest (sin ignición)"
-            "42": "Sensor Motion (sin ignición)"
-
         - name: iccid
           type: string
           length: 20
           pattern: "^[0-9A-Za-z]{20}$"
-          description: "ICCID de la SIM."
-
-        - name: csq_rssi_rsrp
-          type: int
-          min: 0
-          max: 255
-          description: "CSQ RSSI/RSRP (2G/3G: 0–31 o 99; LTE: 0–97 o 255)."
-
-        - name: csq_ber
-          type: int
-          min: 0
-          max: 99
-          description: "CSQ BER (0–7; 99 = desconocido)."
-
-        # --- Alimentación / red / batería ---
-        - name: external_power_supply
-          type: int
-          enum: [0, 1]
-          description: "Fuente externa conectada (0=no, 1=sí)."
-
-        - name: external_power_voltage_mv
-          type: int
-          min: 0
-          max: 99999
-          nullable: true
-          description: "Voltaje fuente externa (mV). Puede venir vacío si no aplica."
-
-        - name: network_type
-          type: int
-          enum: [0, 1, 2, 3]
-          nullable: true
-          description: "Tipo de red (0=Unregistered, 1=EGPRS, 2=Reserved, 3=LTE)."
-
-        - name: backup_battery_voltage_v
-          type: float
-          min: 0.00
-          max: 4.50
-          nullable: true
-          description: "Voltaje batería de respaldo (V)."
-
-        - name: charging
-          type: int
-          enum: [0, 1]
-          description: "Batería cargando (0=no, 1=sí)."
-
-        - name: led_state
-          type: int
-          enum: [0, 1]
-          description: "Estado LEDs (0=todos apagados, 1=alguno encendido)."
-
-        - { name: reserved1, type: string, optional: true, description: "Reservado (puede venir vacío)." }
-        - { name: reserved2, type: string, optional: true, description: "Reservado (puede venir vacío)." }
-
-        # --- Última fix + IO ---
+        - { name: csq_rssi_rsrp, type: int, min: 0, max: 255 }
+        - { name: csq_ber, type: int, min: 0, max: 99 }
+        - { name: external_power_supply, type: int, enum: [0, 1] }
+        - { name: external_power_voltage_mv, type: int, min: 0, max: 99999, nullable: true }
+        - { name: network_type, type: int, enum: [0, 1, 2, 3], nullable: true }
+        - { name: backup_battery_voltage_v, type: float, min: 0.0, max: 4.5, nullable: true }
+        - { name: charging, type: int, enum: [0, 1] }
+        - { name: led_state, type: int, enum: [0, 1] }
+        - { name: reserved1, type: string, optional: true }
+        - { name: reserved2, type: string, optional: true }
         - name: last_fix_utc_time
           type: datetime
           format: "YYYYMMDDHHMMSS"
           tz: "UTC"
-          description: "UTC de la última fix GNSS exitosa."
-
         - name: pin_mask
           type: hex
           length_variant: [1, 2]
-          description: "Modo de trabajo actual de pines (Pin Mask)."
-
-        - name: analog_input_vcc1_mv
-          type: int
-          min: 0
-          max: 16000
-          nullable: true
-          description: "Lectura de Analog Input VCC1 (mV)."
-
-        - { name: reserved3, type: string, optional: true, description: "Reservado (puede venir vacío)." }
-        - { name: reserved4, type: string, optional: true, description: "Reservado (puede venir vacío)." }
-
+        - { name: analog_input_vcc1_mv, type: int, min: 0, max: 16000, nullable: true }
+        - { name: reserved3, type: string, optional: true }
+        - { name: reserved4, type: string, optional: true }
         - name: digital_input
           type: hex
           length_variant: [1, 2]
-          pattern: "^[0-9A-Fa-f]{1,2}$"
-          description: "Estado de entradas digitales (bitwise hex). Rango típico 00–03."
-
         - name: digital_output
           type: hex
           length_variant: [1, 2]
-          pattern: "^[0-9A-Fa-f]{1,2}$"
-          description: "Estado de salidas digitales (bitwise hex). Rango típico 00–01."
-
-        # --- Zona horaria ---
         - name: time_zone_offset
           type: string
           length: 5
           pattern: "^[+-][0-1][0-9][0-5][0-9]$"
-          example: "+0000"
-          description: "Offset local respecto de UTC (+/-HHMM)."
-
-        - name: daylight_saving
-          type: int
-          enum: [0, 1]
-          description: "Horario de verano (0=deshabilitado, 1=habilitado)."
+        - { name: daylight_saving, type: int, enum: [0, 1] }
 
     - name: tail
       fields:
@@ -152,20 +71,9 @@ schema:
           type: datetime
           format: "YYYYMMDDHHMMSS"
           tz: "UTC"
-          description: "Hora UTC en que se generó el reporte."
-        - name: count_number
-          type: hex
-          length: 4
-          description: "Secuencia 0000–FFFF."
+        - { name: count_number, type: hex, length: 4 }
         - { name: tail, const: "$", type: string, optional: true, default_if_absent: "$" }
-
-notes:
-  - "El orden de campos de +RESP/+BUFF:GTINF para GV30CAU incluye Motion Status, ICCID, CSQ RSSI/RSRP, CSQ BER, External Power Supply/Voltage, Network Type, Backup Battery Voltage, Charging, LED State, 2 reservados, Last Fix UTC Time, Pin Mask, Analog Input VCC1, 2 reservados, Digital Input, Digital Output, Time Zone Offset, Daylight Saving, Send Time y Count Number." # :contentReference[oaicite:3]{index=3} :contentReference[oaicite:4]{index=4}
-  - "Motion Status usa los códigos 11,12,16,1A,21,22,41,42 para reposo/movimiento e ignición/sensor." # :contentReference[oaicite:5]{index=5}
-  - "External Power Supply: 0 no conectado, 1 conectado; Network Type: 0 Unregistered, 1 EGPRS, 2 Reserved, 3 LTE." # :contentReference[oaicite:6]{index=6}
-  - "Last Fix UTC Time y Send Time vienen en UTC (YYYYMMDDHHMMSS) y deben convertirse a horario oficial de Chile continental en tu aplicación según corresponda." # :contentReference[oaicite:7]{index=7} :contentReference[oaicite:8]{index=8}
 
 examples:
   raw_frames:
-    # Ejemplo sintético (estructura/orden validado; valores ilustrativos)
     - "+RESP:GTINF,8020210200,868487004398475,GV30CAU,21,898600810906F8048812,28,0,1,12346,3,4.20,0,1,, ,20250314090748,03,12000,, ,03,01,+0000,0,20250314090751,0999$"

--- a/spec/gv30cau/gtjds.yml
+++ b/spec/gv30cau/gtjds.yml
@@ -1,111 +1,60 @@
 name: "GTJDS"
 device: "GV30CAU"
-message_family: "JDS (Network Jamming Indication Notification)"
+message_family: "JDS (Jamming Detection Status)"
 encoding: "ASCII"
 delimiter: ","
 terminator: "$"
 
 version_field:
-name: full_protocol_version
-length: 10
-format: hex
-example: "8020210100"
+  name: full_protocol_version
+  length: 10
+  format: hex
+  example: "8020210100"
 
 schema:
-sections:
-- name: head
-fields:
-- { name: header, const_any: ["+RESP:GTJDS", "+BUFF:GTJDS"], type: string }
-- { name: full_protocol_version, type: hex, length: 10, example: "8020210100" }
-- { name: imei, type: string, length: 15, pattern: "^[0-9]{15}$", example: "868487004398970" }
-- { name: device_name, type: string, max_length: 20, pattern: "^[0-9A-Za-z_-]{1,20}$", example: "GV30CAU" }
+  sections:
+    - name: head
+      fields:
+        - { name: header, const_any: ["+RESP:GTJDS", "+BUFF:GTJDS"], type: string }
+        - { name: full_protocol_version, type: hex, length: 10, example: "8020210100" }
+        - { name: imei, type: string, length: 15, pattern: "^[0-9]{15}$", example: "868487004398970" }
+        - { name: device_name, type: string, max_length: 20, pattern: "^[0-9A-Za-z_-]{1,20}$", example: "GV30CAU" }
 
-```
-- name: body
-  fields:
-    # --- Estado de jamming ---
-    - name: jamming_status
-      type: int
-      enum:
-        1: "quit_jamming_state"
-        2: "enter_jamming_state"
-      description: "Estado actual de jamming (1=salir de jamming, 2=entrar en jamming)."
+    - name: body
+      fields:
+        - { name: jamming_status, type: int, min: 0, max: 2 }
+        - { name: jamming_net, type: int, min: 0, max: 3 }
+        - { name: gnss_accuracy_level, type: int, min: 0, max: 50 }
+        - { name: speed_kmh, type: float, min: 0.0, max: 999.9 }
+        - { name: azimuth_deg, type: int, min: 0, max: 359 }
+        - { name: altitude_m, type: float, nullable: true }
+        - { name: longitude_deg, type: float, nullable: true }
+        - { name: latitude_deg, type: float, nullable: true }
+        - { name: gnss_utc_time, type: datetime, format: "YYYYMMDDHHMMSS", tz: "UTC" }
+        - { name: mcc, type: string, pattern: "^0[0-9]{3}$" }
+        - { name: mnc, type: string, pattern: "^0[0-9]{3}$" }
+        - { name: lac, type: hex, length: 4 }
+        - { name: cell_id, type: hex, length_variant: [4, 8] }
+        - { name: position_append_mask, type: hex, length: 2 }
+        - name: sats_in_use
+          type: int
+          min: 0
+          max: 72
+          nullable: true
+          when: { mask: position_append_mask, bit: 0 }
 
-    - name: jamming_net
-      type: int
-      min: 1
-      max: 3
-      description: "Red donde se detecta jamming: 1=EGPRS/GSM, 2=LTE-Cat1, 3=EGPRS/GSM+LTE."
-
-    # --- Posición GNSS ---
-    - name: gnss_accuracy_level
-      type: int
-      min: 0
-      max: 50
-      description: "GNSS Accuracy (0–50)."
-
-    - { name: speed_kmh, type: float, min: 0.0, max: 999.9 }
-    - { name: azimuth_deg, type: int, min: 0, max: 359 }
-    - { name: altitude_m, type: float, note: "(-)xxxxx.x (m)" }
-    - { name: longitude_deg, type: float, note: "(-)xxx.xxxxxx" }
-    - { name: latitude_deg, type: float, note: "(-)xx.xxxxxx" }
-
-    - name: gnss_utc_time
-      type: datetime
-      format: "YYYYMMDDHHMMSS"
-      tz: "UTC"
-      description: "GNSS UTC Time (UTC). Convertir a hora oficial de Chile continental según DST."
-
-    # --- GSM/Red servidora ---
-    - { name: mcc, type: string, pattern: "^0[0-9]{3}$", description: "0XXX (MCC con 0 prefijo)." }
-    - { name: mnc, type: string, pattern: "^0[0-9]{3}$", description: "0XXX (MNC con 0 prefijo, según spec JDS)." }
-    - { name: lac, type: hex, length: 4 }
-    - { name: cell_id, type: hex, length_variant: [4, 8] }
-
-    # --- Position Append Mask + satélites opcionales ---
-    - name: position_append_mask
-      type: hex
-      length: 2
-      example: "00"
-      description: "Máscara 1 byte (00–FF). Controla campos opcionales posteriores."
-
-    - name: sats_in_use
-      type: int
-      min: 0
-      max: 72
-      optional: true
-      nullable: true
-      when: { mask: position_append_mask, bit: 0 }
-      description: "Satellites in Use (0–72). Campo opcional controlado por Position Append Mask."
-
-- name: tail
-  fields:
-    - name: send_time
-      type: datetime
-      format: "YYYYMMDDHHMMSS"
-      tz: "UTC"
-      description: "Send Time (UTC)."
-
-    - { name: count_number, type: hex, length: 4, description: "Count Number 0000–FFFF." }
-    - { name: tail, const: "$", type: string, optional: true, default_if_absent: "$" }
-```
+    - name: tail
+      fields:
+        - { name: send_time, type: datetime, format: "YYYYMMDDHHMMSS", tz: "UTC" }
+        - { name: count_number, type: hex, length: 4 }
+        - { name: tail, const: "$", type: string, optional: true, default_if_absent: "$" }
 
 masks:
-position_append_mask:
-size_bits: 8
-bits:
-0: { field: sats_in_use, description: "Satellites in Use (Optional)" }
-# Bits 1–7: no documentados para JDS en este protocolo; reservar.
-
-notes:
-
-* "GTJDS (ASCII) se reporta cuando el <Mode> del comando AT+GTJDC está en 2; el equipo envía +RESP:GTJDS cuando se detecta jamming."
-* "Orden de campos JDS: Jamming Status, Jamming Net, GNSS Accuracy, Speed, Azimuth, Altitude, Longitude, Latitude, GNSS UTC Time, MCC, MNC, LAC, Cell ID, Position Append Mask, Satellites in Use (opcional), Send Time, Count Number."
-* "Jamming Net: 1=EGPRS/GSM, 2=LTE-Cat1, 3=EGPRS/GSM+LTE."
-* "GNSS UTC Time y Send Time están en UTC y deben convertirse a horario oficial de Chile continental (con DST) en tu pipeline."
-* "Satellites in Use es opcional y aparece sólo si el Position Append Mask lo habilita."
+  position_append_mask:
+    size_bits: 8
+    bits:
+      0: { field: sats_in_use, description: "Satellites in Use (Optional)" }
 
 examples:
-raw_frames:
-# Ejemplo del protocolo GV30CAU (mismo orden de campos)
-- "+RESP:GTJDS,8020210100,868487004398970,GV30CAU,1,3,0,0.0,190,189.3,117.129604,31.837816,20250303071543,0460,0001,DF5C,05FE6667,00,20250303072530,0139$"
+  raw_frames:
+    - "+RESP:GTJDS,8020210100,868487004398970,GV30CAU,1,3,0,0.0,190,189.3,117.129604,31.837816,20250303071543,0460,0001,DF5C,05FE6667,00,20250303072530,0139$"

--- a/tests/gv30cau/test_parser_gv30cau_reports.py
+++ b/tests/gv30cau/test_parser_gv30cau_reports.py
@@ -1,0 +1,64 @@
+import pytest
+
+from queclink.parser import detect_model_from_identifiers, parse_line
+
+
+@pytest.mark.parametrize(
+    "line, expected_source, expected_report, expected_send_time",
+    [
+        (
+            "+RESP:GTFRI,8020210100,868487004398921,GV30CAU,,10,1,1,26.6,66,21.2,117.248633,31.855967,20250307020609,0460,0000,5666,05C5DF2D,00,13.3,,,,,,220100,,,,20250307020611,2800$",
+            "RESP",
+            "GTFRI",
+            "20250307020611",
+        ),
+        (
+            "+BUFF:GTFRI,8020210100,868487004398921,GV30CAU,12000,10,1,5,60.0,180,50.0,117.129417,31.839262,20250307030323,0460,0001,DF5C,027A4F1F,03,12,2,12345.6,0000012:34:56,12000,0,0,80,220100,0,4,28,,20250307030325,00AF$",
+            "BUFF",
+            "GTFRI",
+            "20250307030325",
+        ),
+        (
+            "+RESP:GTERI,8020210100,868487004398475,GV30CAU,00008000,,10,1,1,0.0,183,151.1,117.129417,31.839262,20250307030112,0460,0001,DF5C,027A4F1F,00,13.6,,,,,,210100,,4,3,20250307030112,0ACC$",
+            "RESP",
+            "GTERI",
+            "20250307030112",
+        ),
+        (
+            "+BUFF:GTERI,8020210100,868487004398475,GV30CAU,00000000,12000,10,1,5,60.0,180,50.0,117.129417,31.839262,20250307030323,0460,0001,DF5C,027A4F1F,00,12345.6,000000,0000012:34:56,28,0,210100,,,,20250307030325,00AF$",
+            "BUFF",
+            "GTERI",
+            "20250307030325",
+        ),
+        (
+            "+RESP:GTINF,8020210200,868487004398475,GV30CAU,21,898600810906F8048812,28,0,1,12346,3,4.20,0,1,, ,20250314090748,03,12000,, ,03,01,+0000,0,20250314090751,0999$",
+            "RESP",
+            "GTINF",
+            "20250314090751",
+        ),
+        (
+            "+RESP:GTJDS,8020210100,868487004398970,GV30CAU,1,3,0,0.0,190,189.3,117.129604,31.837816,20250303071543,0460,0001,DF5C,05FE6667,00,20250303072530,0139$",
+            "RESP",
+            "GTJDS",
+            "20250303072530",
+        ),
+    ],
+)
+def test_parse_line_gv30cau_reports(line, expected_source, expected_report, expected_send_time):
+    parsed = parse_line(line)
+
+    assert parsed["report"] == expected_report
+    assert parsed["source"] == expected_source
+    assert parsed["model"] == "GV30CAU"
+    assert parsed["imei"].startswith("868487004")
+    assert parsed["send_time"] == expected_send_time
+
+    if expected_report == "GTERI":
+        assert "eri_mask" in parsed
+
+
+def test_detect_model_uses_longer_gv30cau_prefix_when_no_device_name():
+    imei = "868487004398475"
+    detected = detect_model_from_identifiers(imei, None)
+
+    assert detected == "GV30CAU"


### PR DESCRIPTION
## Summary
- add GV30CAU model detection from IMEI and device name
- publish cleaned YAML homologation specs for GTINF, GTERI, GTFRI, and GTJDS reports
- cover GV30CAU parsing with dedicated tests

## Testing
- python -m pytest tests/gv30cau


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941badf206083338cf1d44392771a29)