### PR TITLE
Agregar GV30CAU a modelos soportados

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ python queclink_tramas.py --help
 
 El módulo `viz/mapa_recorridos.py` agrega la posibilidad de generar mapas Folium a partir de las bases `gteri_<modelo>.db`, `gtfri_<modelo>.db` y `gtinf_<modelo>.db` generadas por el homologador. Cada mapa agrupa los puntos por IMEI, permite filtrar por operador (Claro, Movistar o Entel), día y tecnología de red (2G/3G/4G), y colorea los recorridos según la calidad de señal calculada a partir de los campos CSQ/RSRP.
 
+### Modelos disponibles (GTERI/GTFRI enriquecidos con GTINF)
+
+- GV310LAU
+- GV350CEU
+- GV58LAU
+- GV30CAU
+
 ### Uso rápido
 
 ```bash

--- a/queclink_tramas.py
+++ b/queclink_tramas.py
@@ -2,7 +2,7 @@
 """
 queclink_gteri_parser.py
 
-Programa para procesar tramas +RESP:GTERI (y +BUFF:GTERI) de equipos Queclink (GV310LAU, GV350CEU, GV58LAU).
+Programa para procesar tramas +RESP:GTERI (y +BUFF:GTERI) de equipos Queclink (GV310LAU, GV350CEU, GV58LAU, GV30CAU).
 - Lee archivos .txt (una trama por línea), .csv o .xlsx (columna con las tramas).
 - Separa campos según los manuales ERI de cada modelo y genera una base SQLite (.db) con tablas por modelo.
 - Requiere: Python 3.9+, pandas, openpyxl (para .xlsx).
@@ -329,7 +329,7 @@ def process_file(in_path: str, out_db: str, sheet: Optional[str]=None, col: Opti
     return total, len(parsed)
 
 def cli():
-    ap = argparse.ArgumentParser(description="Procesador de tramas +RESP:GTERI de Queclink (GV310LAU, GV350CEU, GV58LAU) -> SQLite")
+    ap = argparse.ArgumentParser(description="Procesador de tramas +RESP:GTERI de Queclink (GV310LAU, GV350CEU, GV58LAU, GV30CAU) -> SQLite")
     ap.add_argument("--in", dest="in_path", required=True, help="Ruta de entrada (.txt, .csv, .xlsx)")
     ap.add_argument("--out", dest="out_db", required=True, help="Ruta de salida .db (SQLite)")
     ap.add_argument("--sheet", dest="sheet", help="Nombre/índice de hoja para .xlsx")


### PR DESCRIPTION
### Motivation

- Incluir el modelo Queclink `GV30CAU` en la lista de modelos reconocidos por el procesador y la documentación sin alterar la lógica actual.
- Hacer explícita la disponibilidad del modelo para usuarios que generan mapas a partir de las bases `gteri`, `gtfri` y `gtinf`.

### Description

- Se actualizó el encabezado de `queclink_tramas.py` para listar `GV30CAU` entre los modelos soportados en la documentación del parser.
- Se actualizó la cadena de ayuda del CLI (`argparse`) en `queclink_tramas.py` para mencionar `GV30CAU` en la descripción del procesador.
- Se agregó una sección `Modelos disponibles (GTERI/GTFRI enriquecidos con GTINF)` en `README.md` que lista `GV310LAU`, `GV350CEU`, `GV58LAU` y `GV30CAU`.
- No se modificó la lógica de parsing ni las estructuras de datos existentes; los cambios son únicamente textuales/documentación.

### Testing

- No se ejecutaron pruebas automatizadas tras los cambios.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952ce80f5e08333a95fad60f73ee024)