### PR TITLE
Documentar soporte GV30CAU en README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Queclinck-Homlogador-Tramas
 
 Herramientas para homologar y analizar tramas Queclink (`GTINF, GTERI, GTFRI y GTJDS`) de los
-modelos GV310LAU, GV58LAU, GV350CEU y GV37CAU. Permite convertir archivos de
+modelos GV310LAU, GV58LAU, GV350CEU, GV30CAU y GV37CAU. Permite convertir archivos de
 texto/CSV/XLSX a una base de datos SQLite y, a partir de ella, generar mapas diarios con los
 recorridos diferenciando entre reportes buffer y no buffer.
 
@@ -43,6 +43,7 @@ el nombre de equipo reportado en la trama:
 - `86858906` → **GV310LAU**
 - `86252406` → **GV350CEU**
 - `86631406` → **GV58LAU**
+- `868487004` → **GV30CAU**
 - `86848700` → **GV37CAU**
 
 Si los identificadores no corresponden a un modelo soportado se omite la trama y se deja un log de
@@ -70,7 +71,8 @@ Las bases de datos GTERI / GTFRI y GTINF deben estar en la carpeta `bases_sqlite
 deberían estar con los siguientes nombres `gteri_<modelo>.db`, `gtfri_<modelo>.db` o `gtinf_<modelo>.db`
 (ej: `gteri_gv310lau.db`). Para el equipo **GV75LAU** (que reporta recorridos vía `GTFRI`) asegúrate
 de contar con `gtfri_gv75lau.db` y `gtinf_gv75lau.db` (o sus variantes `_map.db` si ya fueron
-generadas). Actualmente se soportan los modelos GV310LAU, GV58LAU, GV75LAU, GV350CEU y GV37CAU.
+generadas). Actualmente se soportan los modelos GV310LAU, GV58LAU, GV75LAU, GV350CEU, GV30CAU y
+GV37CAU.
 
 El proceso agrega/actualiza las columnas `tecnologia_celular`, `calidad_senal`,
 `nivel_senal_dbm` y `operador`, rellenándolas con la mejor medición `GTINF` disponible para cada


### PR DESCRIPTION
### Motivation
- Reflejar en la documentación que el modelo `GV30CAU` está incluido entre los modelos con spec YAML disponibles.
- Indicar el prefijo IMEI usado para identificar `GV30CAU` en la detección automática de modelo.
- Aclarar que las bases enriquecidas (`gteri_*_map.db` / `gtfri_*_map.db`) ahora consideran `GV30CAU` como modelo soportado.

### Description
- Actualizado `README.md` para añadir `GV30CAU` a la lista de modelos soportados por el proyecto.
- Documentado el prefijo IMEI `868487004` asociado a `GV30CAU` en la sección de detección automática de modelo.
- Añadido `GV30CAU` a la lista de modelos soportados en la sección de "Bases de Datos GTERI o GTFRI Enriquecidas con Datos GTINF".
- Este cambio es exclusivamente documental y no modifica la lógica del parser ni el comportamiento existente del código.

### Testing
- No se ejecutaron tests automatizados porque se trata de un cambio de documentación únicamente.
- El repositorio se mantuvo en estado consistente y el único archivo modificado fue `README.md`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952d3d7ad2c833381a12ded6d7b43a6)