### PR TITLE
Add `csq_rssi_rsrp` to CSQ candidates to fix GV30CAU GTINF signal enrichment

### DIFF
--- a/viz/utils.py
+++ b/viz/utils.py
@@ -49,7 +49,7 @@ OPERATOR_CANDIDATES = [
     "operador_celular",
     "network_operator",
 ]
-CSQ_CANDIDATES = ["csq", "csq_rssi", "csq_rsrp", "lte_csq"]
+CSQ_CANDIDATES = ["csq", "csq_rssi", "csq_rsrp", "csq_rssi_rsrp", "lte_csq"]
 CSQ_BER_CANDIDATES = ["csq_ber", "ber"]
 NETWORK_TYPE_CANDIDATES = ["network_type", "rat", "network"]
 


### PR DESCRIPTION
### Motivation
- GV30CAU GTINF-derived enrichments were leaving `calidad_senal` as "Desconocida" and `nivel_senal_dbm` as NULL because the signal field in GTINF for this model is named differently.
- The enrichment pipeline selects a CSQ column using the `CSQ_CANDIDATES` list in `viz/utils.py`, and the `csq_rssi_rsrp` variant was not included.
- A targeted, minimal change is needed so GV30CAU records get signal quality and dBm without impacting other models.
- This aligns the detector with existing GTINF specs that define `csq_rssi_rsrp` for some devices.

### Description
- Added `"csq_rssi_rsrp"` to the `CSQ_CANDIDATES` list in `viz/utils.py` so that the enrichment code can find that column.
- The change is a single-line update to the candidate list and does not alter classification logic in `classify_signal` or `csq_to_dbm`.
- The modification is constrained to `viz/utils.py` and preserves all existing candidates (`csq`, `csq_rssi`, `csq_rsrp`, `lte_csq`).
- This enables the enriched DB logic to compute `calidad_senal` and `nivel_senal_dbm` when GTINF provides `csq_rssi_rsrp`.

### Testing
- No automated tests were executed for this change.
- The edit is a small, backward-compatible addition limited to signal candidate discovery.
- Existing unit and integration tests that cover enrichment should continue to pass (not re-run here).
- Manual verification is recommended by running the enrichment pipeline on GV30CAU data to confirm `calidad_senal` and `nivel_senal_dbm` are populated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952d99fbfe08333a3551eb1928b512e)